### PR TITLE
Updated 'lint:fix' command to be 'lint-fix'.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
             "phpstan",
             "rector --dry-run"
         ],
-        "lint:fix": [
+        "lint-fix": [
             "rector",
             "cp php-script php-script.php && phpcbf && rm php-script.php"
         ],

--- a/docs/php/composer.md
+++ b/docs/php/composer.md
@@ -26,7 +26,7 @@ The provided [`composer.json`](https://github.com/AlexSkrypnyk/scaffold/blob/mai
   `symfony/console` is provided as a dependency as well.
 
 - **Development Dependencies**:
-  Tools like [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),[PHP Mess Detector](https://phpmd.org/) and [PHPStan](https://phpstan.org/) 
+  Tools like [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),[PHP Mess Detector](https://phpmd.org/) and [PHPStan](https://phpstan.org/)
   for development are listed.
 
 - **Autoloading**:
@@ -38,7 +38,7 @@ The provided [`composer.json`](https://github.com/AlexSkrypnyk/scaffold/blob/mai
 
 - **Custom Scripts**:
   Defines CLI scripts for tasks:
-    - `lint` and `lint:fix` - to lint and fix code using [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),
+    - `lint` and `lint-fix` - to lint and fix code using [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),
       [PHP Mess Detector](https://phpmd.org/) and [PHPStan](https://phpstan.org/)
     - `test` and `test:coverage` - to run PHPUnit tests and generate coverage report
     - `build` - to build a PHAR file (if using as base for CLI command)

--- a/docs/php/linting.md
+++ b/docs/php/linting.md
@@ -20,7 +20,7 @@ the debugging process more efficient.
 
 To lint code, run `composer lint` command.
 
-To fix linting errors, run `composer lint:fix`.
+To fix linting errors, run `composer lint-fix`.
 
 ## PHP Code Sniffer
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     },
     "scripts": {
         "lint": "echo Would run code lint",
+        "lint-fix": "echo Would run code lint fix",
         "test": "echo Would run tests",
         "build": "echo Would run build"
     },


### PR DESCRIPTION
This is to make the command inline with other tools that do not support the `:` syntax in the command.