### PR TITLE
Removed test:coverage command.

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -39,7 +39,7 @@ jobs:
         run: composer lint
 
       - name: Run tests
-        run: composer test:coverage
+        run: XDEBUG_MODE=coverage composer test
 
       - name: Upload coverage report as artifact
         uses: actions/upload-artifact@v4

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,7 @@
             "rector",
             "cp php-script php-script.php && phpcbf && rm php-script.php"
         ],
-        "test": "phpunit --no-coverage",
-        "test:coverage": "XDEBUG_MODE=coverage phpunit",
+        "test": "if [ \"${XDEBUG_MODE}\" = 'coverage' ]; then phpunit; else phpunit --no-coverage; fi",
         "build": [
             "@composer bin box require --dev humbug/box",
             "box validate",

--- a/docs/php/composer.md
+++ b/docs/php/composer.md
@@ -26,7 +26,7 @@ The provided [`composer.json`](https://github.com/AlexSkrypnyk/scaffold/blob/mai
   `symfony/console` is provided as a dependency as well.
 
 - **Development Dependencies**:
-  Tools like [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),[PHP Mess Detector](https://phpmd.org/) and [PHPStan](https://phpstan.org/) 
+  Tools like [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),[PHP Mess Detector](https://phpmd.org/) and [PHPStan](https://phpstan.org/)
   for development are listed.
 
 - **Autoloading**:
@@ -40,7 +40,7 @@ The provided [`composer.json`](https://github.com/AlexSkrypnyk/scaffold/blob/mai
   Defines CLI scripts for tasks:
     - `lint` and `lint:fix` - to lint and fix code using [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer),
       [PHP Mess Detector](https://phpmd.org/) and [PHPStan](https://phpstan.org/)
-    - `test` and `test:coverage` - to run PHPUnit tests and generate coverage report
+    - `test` - to run PHPUnit tests and generate coverage report
     - `build` - to build a PHAR file (if using as base for CLI command)
 
 - **Executable Binaries**:

--- a/docs/php/testing.md
+++ b/docs/php/testing.md
@@ -72,5 +72,5 @@ Here are some of the coverage settings specified in the [phpunit.xml](https://gi
 To generate the coverage reports, run the following command:
 
 ```bash
-composer test:coverage
+XDEBUG_MODE=coverage composer test
 ```


### PR DESCRIPTION
This command belongs in CI and should not be a shortcut command.