### PR TITLE
Fixed BATS testing helper to correctly handle test dir creation.

### DIFF
--- a/tests/bats/_helper.bash
+++ b/tests/bats/_helper.bash
@@ -10,6 +10,8 @@
 ################################################################################
 
 setup() {
+  [ ! -d ".git" ] && echo "Tests must be run from the repository root directory." && exit 1
+
   # For a list of available variables see:
   # @see https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 
@@ -26,35 +28,34 @@ setup() {
   # shellcheck disable=SC2155
   export CUR_DIR="$(pwd)"
 
-  # Allow to run tests in a copy of the repository at the last commit.
-  if [ "${BATS_FIXTURE_EXPORT_CODEBASE_ENABLED-}" = "1" ]; then
-    # Directory where the shell command script will be running in.
-    # As a part of test setup, the local copy of the repository at the last commit
-    # is copied to this location. This means that during development of tests
-    # local changes need to be committed.
-    export BUILD_DIR="${BUILD_DIR:-"${BATS_TEST_TMPDIR//\/\//\/}/shell-command-$(date +%s)"}"
-    fixture_prepare_dir "${BUILD_DIR}"
+  # Project directory root (where .git is located).
+  export ROOT_DIR="${CUR_DIR}"
 
-    # Copy code at the last commit.
-    fixture_export_codebase "${BUILD_DIR}" "${CUR_DIR}"
+  # Directory where the shell command script will be running in.
+  export BUILD_DIR="${BUILD_DIR:-"${BATS_TEST_TMPDIR//\/\//\/}/scaffold-$(date +%s)"}"
+  fixture_prepare_dir "${BUILD_DIR}"
 
-    # Print debug information if "--verbose-run" is passed.
-    # LCOV_EXCL_START
-    if [ "${BATS_VERBOSE_RUN-}" = "1" ]; then
-      echo "BUILD_DIR: ${BUILD_DIR}" >&3
-    fi
-    # LCOV_EXCL_END
+  # Copy codebase at the last commit into the BUILD_DIR.
+  # Tests requiring to work with the copy of the codebase should opt-in using
+  # BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
+  # Note that during development of tests the local changes need to be
+  # committed.
+  fixture_export_codebase "${BUILD_DIR}" "${ROOT_DIR}"
 
-    # Change directory to the current project directory for each test. Tests
-    # requiring to operate outside of BUILD_DIR should change directory explicitly
-    # within their tests.
-    pushd "${BUILD_DIR}" >/dev/null || exit 1
+  # Print debug information if "--verbose-run" is passed.
+  # LCOV_EXCL_START
+  if [ "${BATS_VERBOSE_RUN-}" = "1" ]; then
+    echo "BUILD_DIR: ${BUILD_DIR}" >&3
   fi
+  # LCOV_EXCL_END
+
+  # Change directory to the current project directory for each test. Tests
+  # requiring to operate outside of BUILD_DIR should change directory explicitly
+  # within their tests.
+  pushd "${BUILD_DIR}" >/dev/null || exit 1
 }
 
 teardown() {
-  if [ "${BATS_FIXTURE_EXPORT_CODEBASE_ENABLED-}" = "1" ]; then
-    # Restore the original directory.
-    popd >/dev/null || cd "${CUR_DIR}" || exit 1
-  fi
+  # Move back to the original directory.
+  popd >/dev/null || cd "${CUR_DIR}" || exit 1
 }

--- a/tests/bats/shell-command.bats
+++ b/tests/bats/shell-command.bats
@@ -8,6 +8,8 @@
 
 load _helper
 
+export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+
 # Script file for TUI testing.
 export SCRIPT_FILE=./shell-command.sh
 

--- a/tests/scaffold/_helper.bash
+++ b/tests/scaffold/_helper.bash
@@ -10,6 +10,8 @@
 ################################################################################
 
 setup() {
+  [ ! -d ".git" ] && echo "Tests must be run from the repository root directory." && exit 1
+
   # For a list of available variables see:
   # @see https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 
@@ -26,15 +28,19 @@ setup() {
   # shellcheck disable=SC2155
   export CUR_DIR="$(pwd)"
 
-  # Directory where the init script will be running on.
-  # As a part of test setup, the local copy of Scaffold at the last commit is
-  # copied to this location. This means that during development of tests local
-  # changes need to be committed.
+  # Project directory root (where .git is located).
+  export ROOT_DIR="${CUR_DIR}"
+
+  # Directory where the shell command script will be running in.
   export BUILD_DIR="${BUILD_DIR:-"${BATS_TEST_TMPDIR//\/\//\/}/scaffold-$(date +%s)"}"
   fixture_prepare_dir "${BUILD_DIR}"
 
-  # Copy code at the last commit.
-  fixture_export_codebase "${BUILD_DIR}" "${CUR_DIR}"
+  # Copy codebase at the last commit into the BUILD_DIR.
+  # Tests requiring to work with the copy of the codebase should opt-in using
+  # BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
+  # Note that during development of tests the local changes need to be
+  # committed.
+  fixture_export_codebase "${BUILD_DIR}" "${ROOT_DIR}"
 
   # Print debug information if "--verbose-run" is passed.
   # LCOV_EXCL_START
@@ -50,6 +56,6 @@ setup() {
 }
 
 teardown() {
-  # Restore the original directory.
+  # Move back to the original directory.
   popd >/dev/null || cd "${CUR_DIR}" || exit 1
 }

--- a/tests/scaffold/functional.init.bats
+++ b/tests/scaffold/functional.init.bats
@@ -2,6 +2,9 @@
 #
 # Functional tests for init.sh.
 #
+# Example usage:
+# ./tests/scaffold/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/scaffold
+#
 # shellcheck disable=SC2030,SC2031,SC2129
 
 load _helper
@@ -10,7 +13,6 @@ load _assert_init
 export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
 export SCRIPT_FILE="init.sh"
 
-# ./tests/scaffold/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/scaffold
 # bats test_tags=smoke
 @test "Init, defaults" {
   answers=(


### PR DESCRIPTION


## Checklist before requesting a review

- [ ] I have formatted the subject to include ticket number as `[#123] Verb in past tense with a period at the end.`
- [ ] I have added a link to the issue tracker
- [ ] I have provided information in `Changed` section about WHY something was done if this was not a normal implementation
- [ ] I have performed a self-review of my code and commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run new and existing relevant tests locally with my changes, and they passed
- [ ] I have provided screenshots, where applicable

## Changed

1. Added check that the test is run from the root of the repository (where `.git` resides).
2. Updated how the build directory is created: it should always be created and the tests always should run there instead of the current directory to **avoid accidental removal of the repository itself** because tests could be destructive.
