### PR TITLE
Fixed coverage report uploads to GHA registry.

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           name: ${{github.job}}-code-coverage-report-${{ matrix.php-versions }}
           path: ./.coverage-html
+          if-no-files-found: error
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test-scaffold.yml
+++ b/.github/workflows/test-scaffold.yml
@@ -48,7 +48,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{github.job}}-code-coverage-report
-          path: ./coverage
+          path: ./.scaffold-coverage-html
+          if-no-files-found: error
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -59,6 +59,14 @@ jobs:
         shell: bash
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
+      - name: Upload coverage report as an artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{github.job}}-code-coverage-report
+          path: ./.coverage-html
+          if-no-files-found: error
+
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
- Fixed coverage report for Shell command not being uploaded to GHA build artifcats.
- Fixed GHA not failing on missing coverage report files when uploading to GHA build artifcats.