### PR TITLE
Updated GHA to MacOS 15 and deprecated MacOS 12.

### DIFF
--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -27,9 +27,9 @@ jobs:
           - ubuntu-latest
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721