### PR TITLE
Updated min requirement to PHP 8.3, dropped 8.2 and added 8.5 to CI.

### DIFF
--- a/.github/workflows/release-php.yml
+++ b/.github/workflows/release-php.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
 
       - name: Install dependencies
         run: composer install

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
           ini-values: pcov.directory=.
 
       - name: Install dependencies
-        run: composer install
+        run: composer install ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
 
       - name: Validate composer.json
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
 
       - name: Install dependencies
         run: composer install

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "source": "https://github.com/yournamespace/yourproject"
     },
     "require": {
-        "php": ">=8.2",
-        "symfony/console": "^6.3 || ^7"
+        "php": ">=8.3",
+        "symfony/console": "^7"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",

--- a/rector.php
+++ b/rector.php
@@ -31,6 +31,7 @@ return static function (RectorConfig $rectorConfig): void {
 
   $rectorConfig->sets([
     SetList::PHP_82,
+    SetList::PHP_83,
     SetList::CODE_QUALITY,
     SetList::CODING_STYLE,
     SetList::DEAD_CODE,

--- a/tests/phpunit/Functional/ScriptFunctionalTestCase.php
+++ b/tests/phpunit/Functional/ScriptFunctionalTestCase.php
@@ -27,6 +27,7 @@ abstract class ScriptFunctionalTestCase extends ScriptUnitTestCase {
    */
   const EXIT_ERROR = 1;
 
+  #[\Override]
   protected function setUp(): void {
     parent::setUp();
     // Allow script to run.


### PR DESCRIPTION
PHP 8.2 is EOL.

Also, added support for `Override` attribute https://stitcher.io/blog/override-in-php-83

