### PR TITLE
Decommissioned `macos-13` in GHA.

### DIFF
--- a/.github/workflows/test-shell.yml
+++ b/.github/workflows/test-shell.yml
@@ -27,7 +27,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13
           - macos-14
           - macos-15
     runs-on: ${{ matrix.os }}

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.github/workflows/test-shell.yml
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.github/workflows/test-shell.yml
@@ -27,7 +27,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13
           - macos-14
           - macos-15
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration by removing an outdated macOS version from the test matrix.

**Note:** This release contains no user-facing changes. The modification affects internal testing infrastructure only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->