### PR TITLE
[#388] Fixed `development` version in docs.

### DIFF
--- a/.scaffold/docs/docusaurus.config.js
+++ b/.scaffold/docs/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
             href: 'https://github.com/AlexSkrypnyk/scaffold',
           },
         ],
-        copyright: `Version: ${process.env.RELEASE_VERSION || 'dev'} <br/> Copyright ©${new Date().getFullYear()} Alex Skrypnyk. Built with Docusaurus.`,
+        copyright: `Version: ${process.env.RELEASE_VERSION || 'development'} <br/> Copyright ©${new Date().getFullYear()} Alex Skrypnyk. Built with Docusaurus.`,
       },
       prism: {
         theme: prismThemes.github,

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/docusaurus.config.js
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/docusaurus.config.js
@@ -116,7 +116,7 @@ const config = {
             href: 'https://github.com/yodashut/force-crystal',
           },
         ],
-        copyright: `Version: ${process.env.RELEASE_VERSION || 'dev'} <br/> Copyright ©${new Date().getFullYear()} Luke Skywalker. Built with Docusaurus.`,
+        copyright: `Version: ${process.env.RELEASE_VERSION || 'development'} <br/> Copyright ©${new Date().getFullYear()} Luke Skywalker. Built with Docusaurus.`,
       },
       prism: {
         theme: prismThemes.github,

--- a/.scaffold/tests/phpunit/fixtures/init/name/docs/docusaurus.config.js
+++ b/.scaffold/tests/phpunit/fixtures/init/name/docs/docusaurus.config.js
@@ -55,8 +55,8 @@
 +            href: 'https://github.com/jeditemple/star-forge',
            },
          ],
--        copyright: `Version: ${process.env.RELEASE_VERSION || 'dev'} <br/> Copyright ©${new Date().getFullYear()} Luke Skywalker. Built with Docusaurus.`,
-+        copyright: `Version: ${process.env.RELEASE_VERSION || 'dev'} <br/> Copyright ©${new Date().getFullYear()} Obi-Wan Kenobi. Built with Docusaurus.`,
+-        copyright: `Version: ${process.env.RELEASE_VERSION || 'development'} <br/> Copyright ©${new Date().getFullYear()} Luke Skywalker. Built with Docusaurus.`,
++        copyright: `Version: ${process.env.RELEASE_VERSION || 'development'} <br/> Copyright ©${new Date().getFullYear()} Obi-Wan Kenobi. Built with Docusaurus.`,
        },
        prism: {
          theme: prismThemes.github,

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
             href: 'https://github.com/yournamespace/yourproject',
           },
         ],
-        copyright: `Version: ${process.env.RELEASE_VERSION || 'dev'} <br/> Copyright ©${new Date().getFullYear()} Alex Skrypnyk. Built with Docusaurus.`,
+        copyright: `Version: ${process.env.RELEASE_VERSION || 'development'} <br/> Copyright ©${new Date().getFullYear()} Alex Skrypnyk. Built with Docusaurus.`,
       },
       prism: {
         theme: prismThemes.github,


### PR DESCRIPTION
Related #388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default copyright fallback text in documentation configuration from 'dev' to 'development' across multiple configuration files.
  * Updated documentation site configuration including site URL, repository references, and author metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->