### PR TITLE
[#367] Added Composer 2.9.0 audit configuration with security-focused defaults.

### DIFF
--- a/.scaffold/docs/content/php/composer.mdx
+++ b/.scaffold/docs/content/php/composer.mdx
@@ -46,6 +46,40 @@ which makes them easily accessible without cluttering the global scope.
 - **Configuration**:
 Composer is configured with the following settings:
 
+  - **Security Audit (Composer 2.9.0+)**:
+  Composer 2.9.0 introduced automatic security auditing during install and update operations. The template is configured with security-focused defaults:
+
+    - **`block-insecure: true`** - Blocks installation of packages with known security vulnerabilities (CVE or GHSA advisories) unless explicitly ignored. This enforces security by default and prevents vulnerable dependencies from being installed.
+
+    - **`abandoned: "report"`** - Reports warnings for abandoned/unmaintained packages without failing the build. This provides visibility into maintenance status while allowing flexibility for projects that need to continue using unmaintained packages.
+
+  **Choosing the right audit settings for your project:**
+
+  | Setting | Value | Use Case |
+  |---------|-------|----------|
+  | `block-insecure` | `true` | **Recommended for most projects.** Enforces security by blocking vulnerable packages. Best for production applications where security is critical. |
+  | `block-insecure` | `false` | Only for development/testing environments where you need to temporarily work with vulnerable dependencies. Not recommended for production. |
+  | `abandoned` | `"report"` | **Recommended default.** Shows warnings but doesn't fail builds. Good balance between awareness and flexibility. |
+  | `abandoned` | `"fail"` | Strict mode - fails builds with abandoned packages. Use when you want to enforce active maintenance across all dependencies. |
+  | `abandoned` | `"ignore"` | Suppresses all abandoned package warnings. Only use if you've consciously accepted the maintenance risk. |
+
+  **Temporarily allowing specific vulnerabilities:**
+
+  If you need to temporarily allow a specific vulnerability after security review (e.g., waiting for upstream fix, confirmed false positive, mitigated by other controls), you can add an `ignore` section:
+
+  ```json
+  "audit": {
+    "abandoned": "report",
+    "block-insecure": true,
+    "ignore": {
+      "CVE-2024-1234": "Waiting for upstream fix, mitigated by input validation",
+      "GHSA-xxxx-yyyy-zzzz": "False positive - feature not used in our code"
+    }
+  }
+  ```
+
+  Each ignored advisory should include a brief rationale explaining why it's acceptable for your project. Review and remove these exceptions regularly as fixes become available.
+
   - **Discard Changes**:
   Automatically discards any changes to the `composer.lock` file that are not committed. This ensures a clean state for the dependency versions defined in `composer.json`.
 

--- a/.scaffold/docs/cspell.json
+++ b/.scaffold/docs/cspell.json
@@ -8,6 +8,7 @@
     ],
     "words": [
         "Cobertura",
+        "GHSA",
         "Terminalizer",
         "autoloader",
         "calver",

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/composer.json
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/composer.json
@@ -56,6 +56,10 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true
         },
+        "audit": {
+            "abandoned": "report",
+            "block-insecure": true
+        },
         "discard-changes": true,
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,10 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true
         },
+        "audit": {
+            "abandoned": "report",
+            "block-insecure": true
+        },
         "discard-changes": true,
         "sort-packages": true
     },


### PR DESCRIPTION
Closes #367


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive security audit guide with decision table and a guided example for temporarily allowing specific vulnerabilities.

* **Chores**
  * Enabled default audit behavior to report abandoned packages and block insecure dependencies.
  * Updated docs spell-check dictionary to recognize the "GHSA" token.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->