### PR TITLE
[#364] Improved handling for PascalCase project name in init.sh

### DIFF
--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -31,3 +31,18 @@ load "../../../init.sh"
 
   dataprovider_run "convert_string" 3
 }
+
+@test "Test to_pascalcase conversions" {
+  TEST_CASES=(
+    "my-awesome-project" "MyAwesomeProject"
+    "my_awesome_project" "MyAwesomeProject"
+    "my awesome project" "MyAwesomeProject"
+    "force-crystal" "ForceCrystal"
+    "test-app" "TestApp"
+    "single" "Single"
+    "mix-case_test project" "MixCaseTestProject"
+    "MyAwesomeProject" "MyAwesomeProject"
+  )
+
+  dataprovider_run "to_pascalcase" 2
+}

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/README.md
@@ -1,4 +1,4 @@
-# Yourproject documentation
+# ForceCrystal documentation
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/docusaurus.config.js
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Yourproject',
-  tagline: 'Yourproject documentation',
+  title: 'ForceCrystal',
+  tagline: 'ForceCrystal documentation',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/src/app.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/src/app.php
@@ -12,7 +12,7 @@ use YodasHut\App\Command\JokeCommand;
 use YodasHut\App\Command\SayHelloCommand;
 
 // @codeCoverageIgnoreStart
-$application = new Application('force-crystal', '@force-crystal-version@');
+$application = new Application('YourProject', '@force-crystal-version@');
 
 $command = new JokeCommand();
 $application->add($command);

--- a/.scaffold/tests/phpunit/fixtures/init/name/docs/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/docs/README.md
@@ -1,0 +1,6 @@
+@@ -1,4 +1,4 @@
+-# ForceCrystal documentation
++# StarForge documentation
+ 
+ This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/name/docs/docusaurus.config.js
+++ b/.scaffold/tests/phpunit/fixtures/init/name/docs/docusaurus.config.js
@@ -1,4 +1,11 @@
-@@ -13,7 +13,7 @@
+@@ -8,12 +8,12 @@
+ 
+ /** @type {import('@docusaurus/types').Config} */
+ const config = {
+-  title: 'ForceCrystal',
+-  tagline: 'ForceCrystal documentation',
++  title: 'StarForge',
++  tagline: 'StarForge documentation',
    favicon: 'img/favicon.ico',
  
    // Set the production url of your site here

--- a/.scaffold/tests/phpunit/fixtures/init/name/src/app.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/src/app.php
@@ -8,8 +8,8 @@
 +use JediTemple\App\Command\SayHelloCommand;
  
  // @codeCoverageIgnoreStart
--$application = new Application('force-crystal', '@force-crystal-version@');
-+$application = new Application('star-forge', '@star-forge-version@');
+-$application = new Application('YourProject', '@force-crystal-version@');
++$application = new Application('YourProject', '@star-forge-version@');
  
  $command = new JokeCommand();
  $application->add($command);

--- a/init.sh
+++ b/init.sh
@@ -110,6 +110,9 @@ to_lowercase() {
   echo "${1}" | tr '[:upper:]' '[:lower:]'
 }
 
+# Convert to PascalCase for project names (brief one-liner)
+to_pascalcase() { echo "${1}" | awk -F'[-_ ]' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); } 1' OFS=''; }
+
 remove_string_content() {
   local token="${1}"
   local sed_opts
@@ -389,13 +392,13 @@ process_internal() {
   local namespace="${1}"
   local project="${2}"
   local author="${3}"
+  local project_pascalcase="${4}"
   local namespace_lowercase
 
   namespace_lowercase="$(to_lowercase "${namespace}")"
 
   rm -f LICENSE >/dev/null || true
   rm -f SECURITY.md >/dev/null || true
-  rm -f plan.md >/dev/null || true
   rm -Rf ".scaffold" >/dev/null || true
   rm -f ".github/workflows/scaffold-test.yml" >/dev/null || true
   rm -f ".github/workflows/scaffold-release-docs.yml" >/dev/null || true
@@ -411,6 +414,7 @@ process_internal() {
   replace_string_content "YourNamespace" "${namespace}"
   replace_string_content "yournamespace" "${namespace_lowercase}"
   replace_string_content "yourproject" "${project}"
+  replace_string_content "Yourproject" "${project_pascalcase}"
   replace_string_content "Your Name" "${author}"
   replace_string_content "Alex Skrypnyk" "${author}"
 
@@ -455,6 +459,7 @@ main() {
   # Make sure the input become valid value.
   project="$(convert_string "${project}" "package_name")"
   namespace="$(convert_string "${namespace}" "namespace")"
+  project_pascalcase="$(to_pascalcase "${project}")"
 
   # Validate inputs.
   validate_namespace "${namespace}" || exit 1
@@ -577,7 +582,7 @@ main() {
 
   process_readme "${project}"
 
-  process_internal "${namespace}" "${project}" "${author}"
+  process_internal "${namespace}" "${project}" "${author}" "${project_pascalcase}"
 
   [ "${remove_self}" != "n" ] && rm -- "$0" || true
 

--- a/src/app.php
+++ b/src/app.php
@@ -12,7 +12,7 @@ use YourNamespace\App\Command\JokeCommand;
 use YourNamespace\App\Command\SayHelloCommand;
 
 // @codeCoverageIgnoreStart
-$application = new Application('yourproject', '@yourproject-version@');
+$application = new Application('YourProject', '@yourproject-version@');
 
 $command = new JokeCommand();
 $application->add($command);


### PR DESCRIPTION
Closes #364


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic PascalCase conversion for project names and updated CLI application title.

* **Tests**
  * Added tests validating PascalCase name conversions across delimiters and mixed-case inputs.

* **Documentation**
  * Updated documentation site metadata and README content to reflect a rebrand and new project naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->