### PR TITLE
[#513] Added 'update-consumer-scaffold' skill for updating generated projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 /package-lock.json
 /yarn.lock
 #;> NODEJS
+
+# Claude Code fetches the project update skill on demand; do not commit it.
+/.claude/skills/update-consumer-scaffold/
 #;< META
 /.scaffold-coverage-html
 #;> META

--- a/.scaffold/skills/update-consumer-scaffold/SKILL.md
+++ b/.scaffold/skills/update-consumer-scaffold/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: update-consumer-scaffold
+description: Update a project created from the Scaffold template to the latest version of the Scaffold
+user-invocable: true
+---
+
+# Update Scaffold
+
+When this skill is triggered, follow the steps below to update the current
+project's infrastructure to the latest version of the
+[Scaffold](https://github.com/AlexSkrypnyk/scaffold) template
+([getscaffold.dev](https://getscaffold.dev)).
+
+The strategy is: download a fresh copy of the latest Scaffold, re-run its
+`init.sh` with the answers this project was originally created with, then restore
+the project's own code on top. This refreshes the template-managed
+infrastructure (CI workflows, linting and test configuration, docs scaffolding,
+Docker, etc.) without discarding the project's source code.
+
+## Step 0: Ensure required permissions
+
+This skill requires several Bash commands to run without prompts. Before doing
+anything else, read `.claude/settings.local.json` (create it if it does not
+exist) and ensure the following entries are present in `permissions.allow`. Add
+only the missing ones:
+
+```json
+[
+  "Bash(cat:*)",
+  "Bash(composer:*)",
+  "Bash(cp:*)",
+  "Bash(curl:*)",
+  "Bash(find:*)",
+  "Bash(gh:*)",
+  "Bash(git:*)",
+  "Bash(grep:*)",
+  "Bash(ls:*)",
+  "Bash(mkdir:*)",
+  "Bash(mv:*)",
+  "Bash(npm:*)",
+  "Bash(php:*)",
+  "Bash(rm:*)",
+  "Bash(sed:*)",
+  "Bash(tar:*)",
+  "Bash(./init.sh)"
+]
+```
+
+If any entries were added, tell the user what was added and ask them to restart
+the session. Permissions are loaded at startup, so changes made mid-session do
+not take effect. **STOP here and do not continue** - the user must restart
+Claude Code and re-invoke the skill for the new permissions to apply.
+
+If all entries are already present, proceed to Step 1.
+
+## Step 1: Detect the original init answers
+
+Inspect the initialised project to reconstruct the answers it was created with.
+These map directly to `init.sh` options (run `./init.sh --help` on a fresh
+checkout for the full list).
+
+**Identity:**
+
+1. **Namespace** (PascalCase, e.g. `AcmeApp`): the PSR-4 prefix in
+   `composer.json` `autoload.psr-4` - the segment before `\App\` (e.g.
+   `"AcmeApp\\App\\"` -> `AcmeApp`). If there is no `composer.json`, derive it
+   from the `package.json` scope (`@acmeapp/...`) or ask the user.
+2. **Name** (kebab-case, e.g. `acme-app`): the part after `/` in the
+   `composer.json` `name` field, or the `package.json` `name`, or the
+   command/script/shell file name. If unclear, ask the user.
+3. **Author**: `composer.json` `authors[0].name`, falling back to
+   `git config user.name`. If unclear, ask the user.
+
+**Features** (detect from file/directory presence):
+
+| Option                      | Enabled when                                                |
+|-----------------------------|-------------------------------------------------------------|
+| `--php` / `--no-php`        | `composer.json` exists                                      |
+| `--php-command`             | `src/` directory exists with command classes                |
+| `--php-script`              | a single-file PHP bin exists and there is no `src/`         |
+| `--phar` / `--no-phar`      | `box.json` exists                                           |
+| `--nodejs` / `--no-nodejs`  | `package.json` exists                                       |
+| `--shell` / `--no-shell`    | a `*.sh` command file and `tests/bats/` exist               |
+| `--docker` / `--no-docker`  | `Dockerfile` exists                                         |
+| `--release-drafter`         | `.github/workflows/draft-release-notes.yml` exists          |
+| `--pr-autoassign`           | `.github/workflows/assign-author.yml` exists                |
+| `--funding`                 | `.github/FUNDING.yml` exists                                |
+| `--pr-template`             | `.github/PULL_REQUEST_TEMPLATE.md` exists                   |
+| `--renovate`                | `renovate.json` exists                                      |
+| `--docs`                    | `docs/` directory exists                                    |
+
+**Custom names** (only when they differ from the project name):
+
+- `--php-command-name=<file>` - the PHP CLI command file (the one wrapping
+  `src/app.php`).
+- `--php-script-name=<file>` - the single-file PHP script.
+- `--shell-command-name=<file>` - the `*.sh` file name without the extension.
+- `--docker-image-name=<image>` - read from the `Dockerfile`/CI, defaulting to
+  `<namespace-lowercase>/<name>`.
+
+Also detect the repository **default branch** (not the current checkout):
+
+```bash
+git symbolic-ref --short refs/remotes/origin/HEAD
+```
+
+Strip the `origin/` prefix from the result. If `origin/HEAD` is not set, fall
+back to the branch CI runs on (see `.github/workflows/`), defaulting to `main`.
+
+## Step 2: Get the latest Scaffold version and confirm
+
+```bash
+gh release list --repo AlexSkrypnyk/scaffold --limit 5
+```
+
+Pick the latest non-draft release. **Print the version and the full `init.sh`
+command you assembled in Step 1, and confirm both with the user before making
+any changes.** This is the single most important checkpoint - the rest of the
+process is destructive to the working tree.
+
+If the repository has no releases, fall back to the default-branch tarball in
+Step 5 (`https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz`)
+and label the update with the short commit SHA instead of a version.
+
+## Step 3: Prepare the feature branch
+
+Ensure the working tree is clean and on the default branch, then branch off it.
+This step is **mandatory** - never apply scaffold changes directly to the
+default branch.
+
+```bash
+git switch <default_branch>
+```
+
+```bash
+git pull
+```
+
+```bash
+git switch -c feature/update-scaffold-<version>
+```
+
+## Step 4: Clean the project root
+
+Delete everything in the project root **except** `.git/`, `.claude/` and
+`.idea/`. The project's own code is recovered from git in Step 7.
+
+**IMPORTANT:** This command MUST use a relative path (`.`) and be run from the
+project root. Using an absolute path causes `-name '.'` to fail to match the
+root directory, which results in the root directory itself (including `.git/`)
+being deleted. Ensure the shell working directory is the project root before
+running this command.
+
+```bash
+find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name '.claude' ! -name '.idea' -exec rm -rf {} +
+```
+
+## Step 5: Download and extract the Scaffold
+
+Download the release archive into the project root:
+
+```bash
+gh release download <version> --repo AlexSkrypnyk/scaffold --archive tar.gz --output scaffold.tar.gz
+```
+
+```bash
+tar -xzf scaffold.tar.gz --strip-components=1
+```
+
+```bash
+rm scaffold.tar.gz
+```
+
+(If the repository has no releases, download
+`https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz` with
+`curl -fsSL ... -o scaffold.tar.gz` instead, then extract the same way.)
+
+## Step 6: Run init.sh
+
+Run `init.sh` from the project root, non-interactively, passing **every**
+detected choice explicitly (identity plus each feature's on/off state and any
+custom names). Passing options switches `init.sh` to non-interactive mode.
+
+Example for a project that uses every default feature:
+
+```bash
+./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe"
+```
+
+Example for a shell-only project with a custom command name and no docs:
+
+```bash
+./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe" --no-php --no-nodejs --shell --shell-command-name=acme --no-docs
+```
+
+Build the command from the Step 1 detection. Do not pass `--keep`: the refreshed
+`init.sh` should be removed exactly as it was on the initial setup.
+
+## Step 7: Restore project-specific code from git
+
+The extraction replaced everything, including the project's own code. Restore it
+from the previous commit. Only restore paths that exist - skip any that error:
+
+```bash
+git checkout HEAD -- src tests README.md LICENSE
+```
+
+Add any other project-owned paths (the renamed command/script/shell files, CSS,
+JS, config, etc.) to that command.
+
+**Do not blindly restore `composer.json` or `package.json`.** They contain both
+the project's dependencies and the template's refreshed infrastructure
+(dev-dependencies, scripts). Treat them as a three-way merge: keep the project's
+`require` / `autoload` entries, and take the template's updated dev-dependencies
+and scripts. Review the diff with `git diff HEAD -- composer.json` and reconcile
+by hand.
+
+## Step 8: Review changes
+
+Use `git status` and `git diff` to review everything. Pay attention to:
+
+- **Branch references**: replace the scaffold default branch with the project's
+  default branch in workflow files and the README where needed.
+- **Removed files**: confirm that any files `git status` shows as deleted are
+  genuinely retired by the new Scaffold version, not project files that should
+  have been restored in Step 7.
+- **New files**: review new template files and remove example stubs the project
+  does not need (e.g. example commands or tests it never used).
+- **README.md**: re-apply any structural changes from the template while keeping
+  the project's own content.
+
+## Step 9: Commit
+
+Stage all changes and commit:
+
+```bash
+git add -A
+```
+
+```bash
+git commit -m "Updated scaffold to <version>."
+```
+
+## Step 10: Build, lint, and test
+
+Run the project's quality gates through its wrapper and fix everything they
+report - both warnings and failures. Use the commands that apply to the
+project's selected features:
+
+```bash
+composer install
+```
+
+```bash
+composer lint
+```
+
+```bash
+composer test
+```
+
+For NodeJS projects also run `npm install` and `npm run lint` / `npm test`; for
+shell projects run the BATS suite
+(`./tests/bats/node_modules/.bin/bats tests/bats`). Commit each fix as a
+separate commit.
+
+## Step 11: Open the PR
+
+Push the branch and open a pull request summarising the update (use the
+`/open-pr` skill if available).
+
+## Important notes
+
+- Always confirm the version and the assembled `init.sh` command with the user
+  before starting (Step 2).
+- Never overwrite project-specific code: `src/`, tests, the renamed
+  command/script/shell files, and project documentation are restored from git in
+  Step 7.
+- `init.sh` deletes `.scaffold/`, `init.sh`, `LICENSE` and other
+  template-only files - the same way it did on the initial setup. Restore the
+  project's own `LICENSE` from git if it kept one.
+- After the update, verify workflow branch references match the project's
+  default branch.
+- Prefer the project's wrapper commands (`composer ...`, `npm ...`) over calling
+  the underlying tools directly.
+
+## Command pattern rules
+
+Run commands so they match the allowed permission prefixes and never trigger
+approval prompts.
+
+NEVER use compound or composite commands in a single Bash tool call. Every Bash
+call must contain exactly ONE simple command. No exceptions.
+
+**NEVER use:** `&&`, `||`, `;`, `|`, `<<<`, `$(...)`, heredocs.
+
+**ALWAYS:**
+
+- Use multiple separate Bash tool calls, one command per call.
+- Use non-interactive flags or options for scripts that support them (e.g.
+  `composer --no-interaction`, the `--namespace=`/`--name=`/`--author=` and
+  feature options for `init.sh`).
+- For git commits, use `git commit -m "Message here."`.

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -156,6 +156,34 @@ RENOVATE
   assert_file_contains "${tmpdir}/renovate.json" '"matchManagers": ["npm"]'
 }
 
+@test "protect_skill_references and restore_skill_references round-trip" {
+  local tmpdir="${BATS_TEST_TMPDIR}/skill_refs"
+  mkdir -p "${tmpdir}"
+  cat >"${tmpdir}/AGENTS.md" <<'AGENTS'
+curl https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md
+Invoke the update-consumer-scaffold skill
+ask Claude Code to "update scaffold"
+AGENTS
+
+  pushd "${tmpdir}" >/dev/null || exit 1
+  protect_skill_references
+  popd >/dev/null || exit 1
+
+  assert_file_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL_URL__'
+  assert_file_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL_NAME__'
+  assert_file_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL_TRIGGER__'
+  assert_file_not_contains "${tmpdir}/AGENTS.md" 'AlexSkrypnyk/scaffold'
+
+  pushd "${tmpdir}" >/dev/null || exit 1
+  restore_skill_references
+  popd >/dev/null || exit 1
+
+  assert_file_contains "${tmpdir}/AGENTS.md" 'https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md'
+  assert_file_contains "${tmpdir}/AGENTS.md" 'Invoke the update-consumer-scaffold skill'
+  assert_file_contains "${tmpdir}/AGENTS.md" '"update scaffold"'
+  assert_file_not_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL'
+}
+
 @test "parse_args without arguments keeps interactive mode" {
   parse_args
   assert_equal "${interactive}" "1"

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.gitignore
@@ -10,3 +10,6 @@
 /node_modules
 /package-lock.json
 /yarn.lock
+
+# Claude Code fetches the project update skill on demand; do not commit it.
+/.claude/skills/update-consumer-scaffold/

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/AGENTS.md
@@ -180,3 +180,28 @@ npm run spellcheck # CSpell validation
 ```
 
 Documentation deploys automatically on releases via GitHub Actions.
+
+## Updating from the template
+
+This project was generated from a template and can pull the template's latest
+infrastructure (CI workflows, linting and test configuration, Docker, and docs)
+at any time. When you are asked to "update scaffold", fetch the updater skill
+from the template repository into the local `.claude/skills/` directory, then
+invoke it:
+
+1. Create the target directory if it does not exist:
+
+   ```bash
+   mkdir -p .claude/skills/update-consumer-scaffold
+   ```
+
+2. Download the skill:
+
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md -o .claude/skills/update-consumer-scaffold/SKILL.md
+   ```
+
+3. Invoke the `update-consumer-scaffold` skill and follow its steps.
+
+The skill directory is fetched on demand and is git-ignored - it is not
+committed to the project.

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/README.md
@@ -87,5 +87,10 @@ Download the latest release from GitHub releases page.
     ./tests/bats/node_modules/.bin/bats tests/bats
 
 
+## Updating
+
+To pull the latest infrastructure from the template into this project, ask
+Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
+
 ---
 _This repository was created using the [force-crystal](https://getforce-crystal.dev/) project template_

--- a/.scaffold/tests/phpunit/fixtures/init/docker/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/.gitignore
@@ -1,4 +1,4 @@
-@@ -1,12 +1,3 @@
+@@ -1,15 +1,6 @@
  # To ignore OS temporary files use global .gitignore
  # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
  
@@ -11,3 +11,6 @@
 -/node_modules
 -/package-lock.json
 -/yarn.lock
+ 
+ # Claude Code fetches the project update skill on demand; do not commit it.
+ /.claude/skills/update-consumer-scaffold/

--- a/.scaffold/tests/phpunit/fixtures/init/docker/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/README.md
@@ -59,4 +59,4 @@
 -    ./tests/bats/node_modules/.bin/bats tests/bats
  
  
- ---
+ ## Updating

--- a/.scaffold/tests/phpunit/fixtures/init/name/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/README.md
@@ -73,8 +73,8 @@
  
      npm ci --prefix tests/bats
      ./tests/bats/node_modules/.bin/bats tests/bats
-@@ -88,4 +88,4 @@
- 
+@@ -93,4 +93,4 @@
+ Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
  
  ---
 -_This repository was created using the [force-crystal](https://getforce-crystal.dev/) project template_

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/.gitignore
@@ -1,4 +1,4 @@
-@@ -1,12 +1,3 @@
+@@ -1,15 +1,6 @@
  # To ignore OS temporary files use global .gitignore
  # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer
  
@@ -11,3 +11,6 @@
 -/node_modules
 -/package-lock.json
 -/yarn.lock
+ 
+ # Claude Code fetches the project update skill on demand; do not commit it.
+ /.claude/skills/update-consumer-scaffold/

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/README.md
@@ -59,4 +59,4 @@
 -    ./tests/bats/node_modules/.bin/bats tests/bats
  
  
- ---
+ ## Updating

--- a/.scaffold/tests/phpunit/fixtures/init/php_command/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_command/README.md
@@ -32,4 +32,4 @@
 -    ./tests/bats/node_modules/.bin/bats tests/bats
  
  
- ---
+ ## Updating

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/README.md
@@ -32,4 +32,4 @@
 -    ./tests/bats/node_modules/.bin/bats tests/bats
  
  
- ---
+ ## Updating

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -133,9 +133,10 @@ final class InitTest extends UnitTestCase {
   /**
    * The initialised project keeps the updater skill pointing upstream.
    *
-   * The bulk `scaffold` -> project rewrite in init.sh would otherwise mangle the
-   * self-update skill URL, name, and trigger. They are token-protected, so a
-   * regression here must fail loudly rather than be silently re-baselined.
+   * The bulk `scaffold` -> project rewrite in init.sh would otherwise
+   * mangle the self-update skill URL, name, and trigger. They are
+   * token-protected, so a regression here must fail loudly rather than
+   * being silently re-baselined.
    */
   public function testInitPreservesUpdateSkillReferences(): void {
     self::$fixtures = NULL;

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -130,6 +130,34 @@ final class InitTest extends UnitTestCase {
     $this->assertStringContainsString('YourNamespace', $composer);
   }
 
+  /**
+   * The initialised project keeps the updater skill pointing upstream.
+   *
+   * The bulk `scaffold` -> project rewrite in init.sh would otherwise mangle the
+   * self-update skill URL, name, and trigger. They are token-protected, so a
+   * regression here must fail loudly rather than be silently re-baselined.
+   */
+  public function testInitPreservesUpdateSkillReferences(): void {
+    self::$fixtures = NULL;
+
+    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', [
+      '--namespace=AcmeApp',
+      '--name=acme-app',
+      '--author=Jane Doe',
+    ]);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains('Initialization complete.');
+
+    $agents = (string) file_get_contents(self::$sut . DIRECTORY_SEPARATOR . 'AGENTS.md');
+    $this->assertStringContainsString('https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md', $agents);
+    $this->assertStringContainsString('"update scaffold"', $agents);
+    $this->assertStringNotContainsString('update-consumer-acme-app', $agents);
+
+    $gitignore = (string) file_get_contents(self::$sut . DIRECTORY_SEPARATOR . '.gitignore');
+    $this->assertStringContainsString('/.claude/skills/update-consumer-scaffold/', $gitignore);
+  }
+
   public static function dataProviderInitNonInteractive(): \Iterator {
     $identity = ['--namespace=YodasHut', '--name=force-crystal', '--author=Luke Skywalker'];
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,3 +274,28 @@ npm run spellcheck # CSpell validation
 ```
 
 Documentation deploys automatically on releases via GitHub Actions.
+
+## Updating from the template
+
+This project was generated from a template and can pull the template's latest
+infrastructure (CI workflows, linting and test configuration, Docker, and docs)
+at any time. When you are asked to "update scaffold", fetch the updater skill
+from the template repository into the local `.claude/skills/` directory, then
+invoke it:
+
+1. Create the target directory if it does not exist:
+
+   ```bash
+   mkdir -p .claude/skills/update-consumer-scaffold
+   ```
+
+2. Download the skill:
+
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md -o .claude/skills/update-consumer-scaffold/SKILL.md
+   ```
+
+3. Invoke the `update-consumer-scaffold` skill and follow its steps.
+
+The skill directory is fetched on demand and is git-ignored - it is not
+committed to the project.

--- a/README.dist.md
+++ b/README.dist.md
@@ -107,5 +107,10 @@ Download the latest release from GitHub releases page.
 
 [//]: # (#;> SHELL)
 
+## Updating
+
+To pull the latest infrastructure from the template into this project, ask
+Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
+
 ---
 _This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@
   - [Pull request template](.github/PULL_REQUEST_TEMPLATE.md)
   - [Funding](.github/FUNDING.yml)
   - Init shell script to chose features
+- **AI agents**
+  - [`AGENTS.md`](AGENTS.md) and [`CLAUDE.md`](CLAUDE.md) guidance for AI coding agents
+  - Bundled [`update-consumer-scaffold`](.scaffold/skills/update-consumer-scaffold/SKILL.md)
+    skill that updates a generated project to the latest scaffold release
 
 ## How to use this scaffold repository
 
@@ -91,3 +95,14 @@ curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh 
 ```
 
 Run `./init.sh --help` for the full list of options.
+
+## Updating a generated project
+
+Projects generated from this scaffold can pull later template improvements
+without losing their own code. If you use Claude Code, the bundled
+[`update-consumer-scaffold`](.scaffold/skills/update-consumer-scaffold/SKILL.md)
+skill automates it: in your generated project, ask Claude to "update scaffold"
+and it fetches the skill, downloads the latest scaffold release, re-runs
+`init.sh` with your original answers, restores your project-specific files from
+git, and reconciles the differences. The generated project's
+[`AGENTS.md`](AGENTS.md) carries the same instructions for any AI agent.

--- a/init.sh
+++ b/init.sh
@@ -485,6 +485,29 @@ process_readme() {
   rm logo.tmp.png >/dev/null 2>&1 || true
 }
 
+##
+# Replace the self-update skill references with placeholder tokens.
+#
+# The initialised project must keep instructions that point at the upstream
+# template repository rather than at the project's own namespace, so these
+# references are hidden behind tokens before the bulk replacements run and put
+# back afterwards by restore_skill_references().
+#
+protect_skill_references() {
+  replace_string_content "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md" "__SCAFFOLD_SKILL_URL__"
+  replace_string_content "update-consumer-scaffold" "__SCAFFOLD_SKILL_NAME__"
+  replace_string_content "update scaffold" "__SCAFFOLD_SKILL_TRIGGER__"
+}
+
+##
+# Restore the self-update skill references hidden by protect_skill_references().
+#
+restore_skill_references() {
+  replace_string_content "__SCAFFOLD_SKILL_URL__" "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md"
+  replace_string_content "__SCAFFOLD_SKILL_NAME__" "update-consumer-scaffold"
+  replace_string_content "__SCAFFOLD_SKILL_TRIGGER__" "update scaffold"
+}
+
 process_internal() {
   local namespace="${1}"
   local project="${2}"
@@ -504,12 +527,7 @@ process_internal() {
 
   rm -f "docs/static/img/init.gif" >/dev/null || true
 
-  # Protect the self-update skill references so the initialised project keeps
-  # working instructions that still point at the upstream template repository
-  # rather than at the project's own namespace.
-  replace_string_content "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md" "__SCAFFOLD_SKILL_URL__"
-  replace_string_content "update-consumer-scaffold" "__SCAFFOLD_SKILL_NAME__"
-  replace_string_content "update scaffold" "__SCAFFOLD_SKILL_TRIGGER__"
+  protect_skill_references
 
   # Replace any existing necessary placeholders using a real value with
   # tokens used in further replacements.
@@ -528,10 +546,7 @@ process_internal() {
   replace_string_content "scaffold" "${project}"
   replace_string_content "__ATTRIBUTION__" "https://getscaffold.dev/ project scaffold template"
 
-  # Restore the protected self-update skill references.
-  replace_string_content "__SCAFFOLD_SKILL_URL__" "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md"
-  replace_string_content "__SCAFFOLD_SKILL_NAME__" "update-consumer-scaffold"
-  replace_string_content "__SCAFFOLD_SKILL_TRIGGER__" "update scaffold"
+  restore_skill_references
 
   remove_string_content "# Uncomment the lines below"
   uncomment_line ".gitattributes" "\/.editorconfig"

--- a/init.sh
+++ b/init.sh
@@ -504,6 +504,13 @@ process_internal() {
 
   rm -f "docs/static/img/init.gif" >/dev/null || true
 
+  # Protect the self-update skill references so the initialised project keeps
+  # working instructions that still point at the upstream template repository
+  # rather than at the project's own namespace.
+  replace_string_content "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md" "__SCAFFOLD_SKILL_URL__"
+  replace_string_content "update-consumer-scaffold" "__SCAFFOLD_SKILL_NAME__"
+  replace_string_content "update scaffold" "__SCAFFOLD_SKILL_TRIGGER__"
+
   # Replace any existing necessary placeholders using a real value with
   # tokens used in further replacements.
   replace_string_content "AlexSkrypnyk/scaffold" "yournamespace/yourproject"
@@ -520,6 +527,11 @@ process_internal() {
   replace_string_content "Scaffold" "${project}"
   replace_string_content "scaffold" "${project}"
   replace_string_content "__ATTRIBUTION__" "https://getscaffold.dev/ project scaffold template"
+
+  # Restore the protected self-update skill references.
+  replace_string_content "__SCAFFOLD_SKILL_URL__" "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md"
+  replace_string_content "__SCAFFOLD_SKILL_NAME__" "update-consumer-scaffold"
+  replace_string_content "__SCAFFOLD_SKILL_TRIGGER__" "update scaffold"
 
   remove_string_content "# Uncomment the lines below"
   uncomment_line ".gitattributes" "\/.editorconfig"


### PR DESCRIPTION
Closes #513

## Summary

Adds an `update-consumer-scaffold` Claude Code skill (at `.scaffold/skills/update-consumer-scaffold/SKILL.md`) that lets any project generated from this Scaffold template pull the latest template infrastructure - CI workflows, linting and test config, Docker, docs - without discarding the project's own source code. The skill is fetched on demand via `curl` and is git-ignored so it is never committed to generated projects. `init.sh` token-protects the skill's URL, name, and trigger phrase so the aggressive `scaffold`→project bulk rewrite cannot mangle the self-update instructions that must still point at the upstream template repository. Both a PHPUnit end-to-end test and a BATS unit test guard that protection, and the init snapshot fixtures were regenerated.

## Changes

**New skill** (`.scaffold/skills/update-consumer-scaffold/SKILL.md`): an 11-step guided workflow that reconstructs the original `init.sh` invocation from the consumer project's `composer.json`/`package.json`, downloads the chosen scaffold release, wipes and re-extracts the template, re-runs `init.sh` non-interactively, restores project-specific files from git, and opens a PR.

**`init.sh`**: two helper functions - `protect_skill_references()` and `restore_skill_references()` - called from `process_internal()`. Before the bulk `scaffold`→project rewrite, the skill URL (`https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md`), skill name (`update-consumer-scaffold`), and trigger phrase (`update scaffold`) are swapped to sentinel tokens (`__SCAFFOLD_SKILL_URL__`, `__SCAFFOLD_SKILL_NAME__`, `__SCAFFOLD_SKILL_TRIGGER__`). After the rewrite the sentinels are swapped back to the originals.

**`AGENTS.md`** / **`README.dist.md`** (consumer template files): new "Updating from the template" / "Updating" sections with the two-command fetch-on-demand instructions (`mkdir -p` + `curl`).

**`README.md`** (template repo docs): new AI-agents bullet in the features list and an "Updating a generated project" section explaining the end-to-end flow.

**`.gitignore`**: ignores `/.claude/skills/update-consumer-scaffold/` so the fetched skill directory is never accidentally committed.

**Tests**: `testInitPreservesUpdateSkillReferences` (PHPUnit, `.scaffold/tests/phpunit/src/InitTest.php`) runs a full `init.sh` invocation and asserts the resulting `AGENTS.md` still contains the upstream URL and trigger phrase and does not contain a mangled `update-consumer-acme-app` name. A BATS unit test (`.scaffold/tests/bats/init.bats`) exercises the `protect_skill_references()`/`restore_skill_references()` round-trip directly.

**Snapshot fixtures** (`.scaffold/tests/phpunit/fixtures/init/`): `_baseline`, `docker`, `no_languages`, `name`, `php_command`, `php_script` updated to reflect the new `.gitignore` entry and `README.md` "Updating" section.

## Before / After

```
BEFORE (init.sh bulk rewrite mangled the skill)
───────────────────────────────────────────────
Template AGENTS.md
  curl ...AlexSkrypnyk/scaffold.../update-consumer-scaffold/SKILL.md
  Invoke: update-consumer-scaffold
          ↓ init.sh rewrite: "scaffold" → "acme-app"
Consumer AGENTS.md (broken)
  curl ...AlexSkrypnyk/acme-app.../update-consumer-acme-app/SKILL.md  ← 404
  Invoke: update-consumer-acme-app                                    ← wrong


AFTER (token-protection preserves the upstream references)
──────────────────────────────────────────────────────────
Template AGENTS.md
  curl ...AlexSkrypnyk/scaffold.../update-consumer-scaffold/SKILL.md
  Invoke: update-consumer-scaffold
          ↓ init.sh: protect_skill_references() before rewrite,
            restore_skill_references() after
Consumer AGENTS.md (correct)
  curl ...AlexSkrypnyk/scaffold.../update-consumer-scaffold/SKILL.md  ← still valid
  Invoke: update-consumer-scaffold                                     ← correct

Fetch-on-demand flow in a consumer project:
  user: "update scaffold"
    → AGENTS.md instructions: mkdir + curl from AlexSkrypnyk/scaffold
    → .claude/skills/update-consumer-scaffold/SKILL.md (fetched, git-ignored)
    → skill runs 11-step update: detect answers → confirm → branch → clean
      → download release → init.sh → restore src/ → review → commit → PR
```
