### PR TITLE
Added committed Claude Code settings trimmed to selected features.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer:*)",
+      "Bash(./vendor/bin/phpcs:*)",
+      "Bash(./vendor/bin/phpcbf:*)",
+      "Bash(./vendor/bin/phpstan:*)",
+      "Bash(./vendor/bin/rector:*)",
+      "Bash(./vendor/bin/phpunit:*)",
+      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+      "Bash(npm:*)",
+      "Bash(docker build:*)",
+      "Bash(docker run:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@
 /yarn.lock
 #;> NODEJS
 
+# Temporary AI agent and developer artifacts (plans, scratch output, reports).
+/.artifacts/
+
+# Claude Code settings are shared; personal overrides stay local.
+!/.claude/
+/.claude/settings.local.json
 # Claude Code fetches the project update skill on demand; do not commit it.
 /.claude/skills/update-consumer-scaffold/
 #;< META

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -128,31 +128,47 @@ Same pattern used in `phpcs.xml` (`<file>php-script.php</file>`).
   - Purpose: Validate `shell-command.sh` functionality
   - Includes: TUI testing helpers, mocking system via `run_steps()`
 
-### Test Code Conventions
+### Rules for Template Changes
 
-The init test suite lives in `.scaffold/tests/phpunit/` and is built on the
-maintainer's own helper packages. New tests must read like the existing ones:
+The init/template machinery has its OWN test suite in `.scaffold/tests/phpunit/`,
+separate from the repo root, with its own `composer.json`, `phpcs.xml`,
+`phpstan.neon`, and `vendor/`.
 
-- **Filesystem operations use `alexskrypnyk/file`, never Symfony `Filesystem`
-  or raw PHP.** Reach for the `AlexSkrypnyk\File\File` static API instead of
-  `copy()`, `file_get_contents()`, `mkdir()`, `unlink()`, or
-  `new \Symfony\Component\Filesystem\Filesystem()`:
-  - Copy: `File::copy()`, `File::copyIfExists()`
-  - Read/write: `File::read()`, `File::dump()`, `File::append()`
-  - Query: `File::exists()`, `File::dir()`, `File::scandir()`,
-    `File::contains()`
-  - Mutate: `File::mkdir()`, `File::remove()`, `File::renameInDir()`,
-    `File::replaceContentInDir()`, `File::removeTokenInDir()`
+- **Run the suite that matches your change.** Repo-root `composer lint` /
+  `composer test` cover ONLY the example application (`src/`, `tests/`) and pass
+  even when the template is broken. A green root lint is NOT proof the init suite
+  is green - any change to `init.sh`, template files, or fixtures must be
+  validated from the init suite:
 
-- **Use the helper traits composed by `UnitTestCase`; do not re-implement
-  their behavior:**
-  - `alexskrypnyk/phpunit-helpers`: `LocationsTrait` (`locationsCopy()`,
-    `locationsRealpath()`, the `self::$sut` / `self::$tmp` dirs), `ProcessTrait`
-    (`processRun()`, `assertProcessSuccessful()`,
-    `assertProcessOutputContains()`), `TuiTrait` (drives interactive prompts),
-    and `SerializableClosureTrait`.
-  - `alexskrypnyk/snapshot`: `SnapshotTrait` (`assertSnapshotMatchesBaseline()`)
-    plus the `update-snapshots` binary used by `composer update-snapshots`.
+```bash
+cd .scaffold/tests/phpunit
+composer lint    # phpcs (Drupal standard), phpstan level 9, rector
+composer test    # InitTest snapshot suite
+```
+
+- **Coding standard is Drupal.** Comment lines wrap at 80 characters
+  (`Drupal.Files.LineLength.TooLong`); code lines have no length limit. Tests may
+  omit parameter docblocks, but annotate any `mixed` value (e.g. a data-provider
+  row) with `@param list<string>` so phpstan level 9 stays clean.
+
+- **Use the maintainer helper libraries, never Symfony or raw PHP.** File work
+  goes through `alexskrypnyk/file` (`File::copyIfExists()`, `File::dir()`,
+  `File::exists()`, `File::dump()`, `File::remove()`, ...); test scaffolding
+  comes from `alexskrypnyk/phpunit-helpers` traits on `UnitTestCase`
+  (`LocationsTrait` -> `locationsCopy()` / `self::$sut`; `ProcessTrait` ->
+  `processRun()` / `assertProcess*()`; `TuiTrait` for interactive prompts) and
+  `alexskrypnyk/snapshot` (`SnapshotTrait`, `update-snapshots`).
+
+- **After changing template files, regenerate fixtures** with
+  `composer update-snapshots` from `.scaffold/tests/phpunit` (see "Updating
+  Fixtures"). It auto-commits the regenerated fixtures itself, so review the diff
+  before running it.
+
+- **Gotcha: a global gitignore of `.claude` / `.artifacts` silently drops fixture
+  dirs.** Fixture scenarios ship `.claude/settings.json`; an unanchored
+  `~/.gitignore` `.claude` rule makes `git add` skip them with no error.
+  `fixtures/.gitignore` carries a `!.claude/` negation to override it - keep it,
+  and confirm staged files with `git ls-files --others --exclude-standard`.
 
 ### Running Template Tests
 

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -151,6 +151,11 @@ composer test    # InitTest snapshot suite
   omit parameter docblocks, but annotate any `mixed` value (e.g. a data-provider
   row) with `@param list<string>` so phpstan level 9 stays clean.
 
+- **Shell scripts must pass `shfmt`.** The `Shell` and `Test Scaffold` CI jobs
+  run `shfmt -i 2 -ci -s` (via `luizm/action-sh-checker`) over `init.sh` and the
+  `*.sh` / `.bats` files, and it is strict about redirect spacing (`>"$f"`, not
+  `> "$f"`). Format shell edits to match before pushing.
+
 - **Use the maintainer helper libraries, never Symfony or raw PHP.** File work
   goes through `alexskrypnyk/file` (`File::copyIfExists()`, `File::dir()`,
   `File::exists()`, `File::dump()`, `File::remove()`, ...); test scaffolding

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -128,6 +128,32 @@ Same pattern used in `phpcs.xml` (`<file>php-script.php</file>`).
   - Purpose: Validate `shell-command.sh` functionality
   - Includes: TUI testing helpers, mocking system via `run_steps()`
 
+### Test Code Conventions
+
+The init test suite lives in `.scaffold/tests/phpunit/` and is built on the
+maintainer's own helper packages. New tests must read like the existing ones:
+
+- **Filesystem operations use `alexskrypnyk/file`, never Symfony `Filesystem`
+  or raw PHP.** Reach for the `AlexSkrypnyk\File\File` static API instead of
+  `copy()`, `file_get_contents()`, `mkdir()`, `unlink()`, or
+  `new \Symfony\Component\Filesystem\Filesystem()`:
+  - Copy: `File::copy()`, `File::copyIfExists()`
+  - Read/write: `File::read()`, `File::dump()`, `File::append()`
+  - Query: `File::exists()`, `File::dir()`, `File::scandir()`,
+    `File::contains()`
+  - Mutate: `File::mkdir()`, `File::remove()`, `File::renameInDir()`,
+    `File::replaceContentInDir()`, `File::removeTokenInDir()`
+
+- **Use the helper traits composed by `UnitTestCase`; do not re-implement
+  their behavior:**
+  - `alexskrypnyk/phpunit-helpers`: `LocationsTrait` (`locationsCopy()`,
+    `locationsRealpath()`, the `self::$sut` / `self::$tmp` dirs), `ProcessTrait`
+    (`processRun()`, `assertProcessSuccessful()`,
+    `assertProcessOutputContains()`), `TuiTrait` (drives interactive prompts),
+    and `SerializableClosureTrait`.
+  - `alexskrypnyk/snapshot`: `SnapshotTrait` (`assertSnapshotMatchesBaseline()`)
+    plus the `update-snapshots` binary used by `composer update-snapshots`.
+
 ### Running Template Tests
 
 ```bash

--- a/.scaffold/docs/content/ai-integration.mdx
+++ b/.scaffold/docs/content/ai-integration.mdx
@@ -1,0 +1,50 @@
+---
+title: AI integration
+sidebar_position: 7
+---
+
+# AI integration
+
+This template ships configuration that lets AI coding agents work with a
+generated project out of the box: shared guidance about the project and a
+pre-approved list of the commands the project uses.
+
+## `AGENTS.md`
+
+The `AGENTS.md` file provides agent-agnostic guidance about the project - its
+architecture, the commands used to lint, test and build it, and the coding
+conventions to follow. It follows the [AGENTS.md](https://agents.md/) convention
+supported by many AI coding tools.
+
+This template provides an [`AGENTS.md`](https://github.com/AlexSkrypnyk/scaffold/blob/main/AGENTS.md)
+tailored to the features selected during initialization.
+
+## `CLAUDE.md`
+
+The `CLAUDE.md` file is the entry point read by [Claude Code](https://www.claude.com/product/claude-code).
+It only includes `AGENTS.md`, so there is a single source of guidance shared
+across agents.
+
+## `.claude/settings.json`
+
+The `.claude/settings.json` file lists the project commands that Claude Code is
+allowed to run without asking for confirmation each time - for example linting,
+testing and building. It is committed to the repository so the whole team shares
+the same pre-approved list.
+
+The list is derived from the commands documented in `AGENTS.md`. During
+initialization, `init.sh` trims the list to the features you selected, so a
+project without Docker, for instance, does not pre-approve Docker commands.
+
+## `.claude/settings.local.json`
+
+The `.claude/settings.local.json` file holds personal permission overrides. It
+is git-ignored, so it is never shared with the team or shipped with the project.
+Use it for machine-specific or experimental permissions.
+
+## `.artifacts`
+
+The `.artifacts` directory is a scratch location for temporary AI and developer
+artifacts - generated plans, notes, reports and other throwaway output. It is
+git-ignored and never committed, which keeps transient files out of the
+repository while giving agents and developers a consistent place to write them.

--- a/.scaffold/docs/cspell.json
+++ b/.scaffold/docs/cspell.json
@@ -7,6 +7,7 @@
         "softwareTerms"
     ],
     "words": [
+        "Claude",
         "Cobertura",
         "GHSA",
         "Terminalizer",

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -373,3 +373,159 @@ WORKFLOW
   assert_success
   assert_output_contains "Use scheduled builds             : n"
 }
+
+create_claude_settings() {
+  mkdir -p "${1}/.claude"
+  cat >"${1}/.claude/settings.json" <<'SETTINGS'
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer:*)",
+      "Bash(./vendor/bin/phpcs:*)",
+      "Bash(./vendor/bin/phpcbf:*)",
+      "Bash(./vendor/bin/phpstan:*)",
+      "Bash(./vendor/bin/rector:*)",
+      "Bash(./vendor/bin/phpunit:*)",
+      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+      "Bash(npm:*)",
+      "Bash(docker build:*)",
+      "Bash(docker run:*)"
+    ]
+  }
+}
+SETTINGS
+}
+
+@test "process_claude_settings keeps every rule when all features are selected" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_all"
+  mkdir -p "${tmpdir}"
+  create_claude_settings "${tmpdir}"
+
+  use_php="y"
+  use_shell="y"
+  use_nodejs="y"
+  use_docs="y"
+  use_docker="y"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_file_contains "${tmpdir}/.claude/settings.json" "composer:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "bats:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "npm:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "docker build:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "docker run:"
+}
+
+@test "process_claude_settings removes PHP rules when PHP is not selected" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_no_php"
+  mkdir -p "${tmpdir}"
+  create_claude_settings "${tmpdir}"
+
+  use_php="n"
+  use_shell="y"
+  use_nodejs="y"
+  use_docs="y"
+  use_docker="y"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "composer:"
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "phpstan:"
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "phpunit:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "bats:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "npm:"
+}
+
+@test "process_claude_settings removes the bats rule when shell is not selected" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_no_shell"
+  mkdir -p "${tmpdir}"
+  create_claude_settings "${tmpdir}"
+
+  use_php="y"
+  use_shell="n"
+  use_nodejs="y"
+  use_docs="y"
+  use_docker="y"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "bats:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "composer:"
+}
+
+@test "process_claude_settings removes Docker rules when Docker is not selected" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_no_docker"
+  mkdir -p "${tmpdir}"
+  create_claude_settings "${tmpdir}"
+
+  use_php="y"
+  use_shell="y"
+  use_nodejs="y"
+  use_docs="y"
+  use_docker="n"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "docker build:"
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "docker run:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "npm:"
+}
+
+@test "process_claude_settings keeps npm when docs is selected without NodeJS" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_docs_npm"
+  mkdir -p "${tmpdir}"
+  create_claude_settings "${tmpdir}"
+
+  use_php="y"
+  use_shell="y"
+  use_nodejs="n"
+  use_docs="y"
+  use_docker="y"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_file_contains "${tmpdir}/.claude/settings.json" "npm:"
+}
+
+@test "process_claude_settings removes npm when neither NodeJS nor docs is selected" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_no_npm"
+  mkdir -p "${tmpdir}"
+  create_claude_settings "${tmpdir}"
+
+  use_php="y"
+  use_shell="y"
+  use_nodejs="n"
+  use_docs="n"
+  use_docker="y"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_file_not_contains "${tmpdir}/.claude/settings.json" "npm:"
+  assert_file_contains "${tmpdir}/.claude/settings.json" "composer:"
+}
+
+@test "process_claude_settings is a no-op when the settings file is absent" {
+  local tmpdir="${BATS_TEST_TMPDIR}/claude_absent"
+  mkdir -p "${tmpdir}"
+
+  use_php="n"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  run process_claude_settings
+  popd >/dev/null || return 1
+
+  assert_success
+  assert_file_not_exists "${tmpdir}/.claude/settings.json"
+}

--- a/.scaffold/tests/phpunit/fixtures/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/.gitignore
@@ -1,1 +1,5 @@
 .expected
+
+# Track the generated '.claude/settings.json' fixtures even when a developer's
+# global gitignore excludes '.claude' directories.
+!.claude/

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(composer:*)",
+      "Bash(./vendor/bin/phpcs:*)",
+      "Bash(./vendor/bin/phpcbf:*)",
+      "Bash(./vendor/bin/phpstan:*)",
+      "Bash(./vendor/bin/rector:*)",
+      "Bash(./vendor/bin/phpunit:*)",
+      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+      "Bash(npm:*)"
+    ]
+  }
+}

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.gitignore
@@ -11,5 +11,11 @@
 /package-lock.json
 /yarn.lock
 
+# Temporary AI agent and developer artifacts (plans, scratch output, reports).
+/.artifacts/
+
+# Claude Code settings are shared; personal overrides stay local.
+!/.claude/
+/.claude/settings.local.json
 # Claude Code fetches the project update skill on demand; do not commit it.
 /.claude/skills/update-consumer-scaffold/

--- a/.scaffold/tests/phpunit/fixtures/init/docker/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/.claude/settings.json
@@ -1,0 +1,18 @@
+@@ -1,14 +1,9 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(composer:*)",
+-      "Bash(./vendor/bin/phpcs:*)",
+-      "Bash(./vendor/bin/phpcbf:*)",
+-      "Bash(./vendor/bin/phpstan:*)",
+-      "Bash(./vendor/bin/rector:*)",
+-      "Bash(./vendor/bin/phpunit:*)",
+-      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+-      "Bash(npm:*)"
++      "Bash(npm:*)",
++      "Bash(docker build:*)",
++      "Bash(docker run:*)"
+     ]
+   }
+ }

--- a/.scaffold/tests/phpunit/fixtures/init/docker/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/.gitignore
@@ -12,5 +12,5 @@
 -/package-lock.json
 -/yarn.lock
  
- # Claude Code fetches the project update skill on demand; do not commit it.
- /.claude/skills/update-consumer-scaffold/
+ # Temporary AI agent and developer artifacts (plans, scratch output, reports).
+ /.artifacts/

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/.claude/settings.json
@@ -1,0 +1,14 @@
+@@ -1,13 +1,6 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(composer:*)",
+-      "Bash(./vendor/bin/phpcs:*)",
+-      "Bash(./vendor/bin/phpcbf:*)",
+-      "Bash(./vendor/bin/phpstan:*)",
+-      "Bash(./vendor/bin/rector:*)",
+-      "Bash(./vendor/bin/phpunit:*)",
+-      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+       "Bash(npm:*)"
+     ]
+   }

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/.gitignore
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/.gitignore
@@ -12,5 +12,5 @@
 -/package-lock.json
 -/yarn.lock
  
- # Claude Code fetches the project update skill on demand; do not commit it.
- /.claude/skills/update-consumer-scaffold/
+ # Temporary AI agent and developer artifacts (plans, scratch output, reports).
+ /.artifacts/

--- a/.scaffold/tests/phpunit/fixtures/init/nodejs/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/nodejs/.claude/settings.json
@@ -1,0 +1,13 @@
+@@ -1,12 +1,6 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(composer:*)",
+-      "Bash(./vendor/bin/phpcs:*)",
+-      "Bash(./vendor/bin/phpcbf:*)",
+-      "Bash(./vendor/bin/phpstan:*)",
+-      "Bash(./vendor/bin/rector:*)",
+-      "Bash(./vendor/bin/phpunit:*)",
+       "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+       "Bash(npm:*)"
+     ]

--- a/.scaffold/tests/phpunit/fixtures/init/php_command/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/php_command/.claude/settings.json
@@ -1,0 +1,8 @@
+@@ -7,7 +7,6 @@
+       "Bash(./vendor/bin/phpstan:*)",
+       "Bash(./vendor/bin/rector:*)",
+       "Bash(./vendor/bin/phpunit:*)",
+-      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+       "Bash(npm:*)"
+     ]
+   }

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/.claude/settings.json
@@ -1,0 +1,8 @@
+@@ -7,7 +7,6 @@
+       "Bash(./vendor/bin/phpstan:*)",
+       "Bash(./vendor/bin/rector:*)",
+       "Bash(./vendor/bin/phpunit:*)",
+-      "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+       "Bash(npm:*)"
+     ]
+   }

--- a/.scaffold/tests/phpunit/fixtures/init/shell/.claude/settings.json
+++ b/.scaffold/tests/phpunit/fixtures/init/shell/.claude/settings.json
@@ -1,0 +1,13 @@
+@@ -1,12 +1,6 @@
+ {
+   "permissions": {
+     "allow": [
+-      "Bash(composer:*)",
+-      "Bash(./vendor/bin/phpcs:*)",
+-      "Bash(./vendor/bin/phpcbf:*)",
+-      "Bash(./vendor/bin/phpstan:*)",
+-      "Bash(./vendor/bin/rector:*)",
+-      "Bash(./vendor/bin/phpunit:*)",
+       "Bash(./tests/bats/node_modules/bats/bin/bats:*)",
+       "Bash(npm:*)"
+     ]

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -208,8 +208,8 @@ final class InitTest extends UnitTestCase {
     $this->assertFileDoesNotExist($claude_dir . DIRECTORY_SEPARATOR . 'settings.local.json');
 
     $content = (string) file_get_contents($claude_dir . DIRECTORY_SEPARATOR . 'settings.json');
-    // Decoding without errors also proves the file stays valid JSON (no dangling
-    // comma) after rules are trimmed.
+    // Decoding without errors proves the file is valid JSON (no dangling
+    // comma) after trimming.
     $this->assertJson($content);
 
     foreach ($present as $rule) {

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -184,6 +184,81 @@ final class InitTest extends UnitTestCase {
     $this->assertProcessSuccessful();
   }
 
+  /**
+   * The shared Claude settings ship and are trimmed to the selected features.
+   *
+   * @param list<string> $arguments
+   *   Command-line arguments passed to init.sh.
+   * @param list<string> $present
+   *   Permission rules that must be present in the settings file.
+   * @param list<string> $absent
+   *   Permission rules that must be absent from the settings file.
+   */
+  #[DataProvider('dataProviderClaudeSettings')]
+  public function testInitClaudeSettings(array $arguments, array $present, array $absent): void {
+    self::$fixtures = NULL;
+
+    $arguments = array_merge(['--namespace=AcmeApp', '--name=acme-app', '--author=Jane Doe'], $arguments);
+    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', $arguments);
+    $this->assertProcessSuccessful();
+
+    $claude_dir = self::$sut . DIRECTORY_SEPARATOR . '.claude';
+    $this->assertFileExists($claude_dir . DIRECTORY_SEPARATOR . 'settings.json');
+    // Personal overrides must never leak into a generated project.
+    $this->assertFileDoesNotExist($claude_dir . DIRECTORY_SEPARATOR . 'settings.local.json');
+
+    $content = (string) file_get_contents($claude_dir . DIRECTORY_SEPARATOR . 'settings.json');
+    // Decoding without errors also proves the file stays valid JSON (no dangling
+    // comma) after rules are trimmed.
+    $this->assertJson($content);
+
+    foreach ($present as $rule) {
+      $this->assertStringContainsString('"' . $rule . '"', $content);
+    }
+    foreach ($absent as $rule) {
+      $this->assertStringNotContainsString('"' . $rule . '"', $content);
+    }
+
+    $gitignore = (string) file_get_contents(self::$sut . DIRECTORY_SEPARATOR . '.gitignore');
+    $this->assertStringContainsString('!/.claude/', $gitignore);
+    $this->assertStringContainsString('/.claude/settings.local.json', $gitignore);
+    $this->assertStringContainsString('/.artifacts/', $gitignore);
+  }
+
+  public static function dataProviderClaudeSettings(): \Iterator {
+    // Docker is off by default, so its rules are trimmed unless enabled.
+    yield 'defaults' => [
+      [],
+      ['Bash(composer:*)', 'Bash(./vendor/bin/phpunit:*)', 'Bash(./tests/bats/node_modules/bats/bin/bats:*)', 'Bash(npm:*)'],
+      ['Bash(docker build:*)', 'Bash(docker run:*)'],
+    ];
+    yield 'with docker' => [
+      ['--docker'],
+      ['Bash(docker build:*)', 'Bash(docker run:*)'],
+      [],
+    ];
+    yield 'no php' => [
+      ['--no-php'],
+      ['Bash(./tests/bats/node_modules/bats/bin/bats:*)', 'Bash(npm:*)'],
+      ['Bash(composer:*)', 'Bash(./vendor/bin/phpcs:*)', 'Bash(./vendor/bin/phpunit:*)'],
+    ];
+    yield 'npm survives via docs without nodejs' => [
+      ['--no-nodejs'],
+      ['Bash(npm:*)'],
+      [],
+    ];
+    yield 'npm trimmed without nodejs and docs' => [
+      ['--no-nodejs', '--no-docs'],
+      [],
+      ['Bash(npm:*)'],
+    ];
+    yield 'no languages' => [
+      ['--no-php', '--no-nodejs', '--no-shell', '--no-docs'],
+      [],
+      ['Bash(composer:*)', 'Bash(npm:*)', 'Bash(./tests/bats/node_modules/bats/bin/bats:*)'],
+    ];
+  }
+
   public static function dataProviderInitNonInteractive(): \Iterator {
     $identity = ['--namespace=YodasHut', '--name=force-crystal', '--author=Luke Skywalker'];
 

--- a/.scaffold/tests/phpunit/src/UnitTestCase.php
+++ b/.scaffold/tests/phpunit/src/UnitTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\Scaffold\Tests;
 
+use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\SerializableClosureTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\TuiTrait;
@@ -30,6 +31,12 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
       '.phpunit.cache',
       '.claude',
     ]);
+
+    // The template ships a shared '.claude/settings.json'; personal overrides
+    // in '.claude/settings.local.json' are git-ignored and must never leak into
+    // a generated project, so copy only the shared file (the bulk copy above
+    // skips the whole '.claude' directory to keep local overrides out).
+    File::copyIfExists(static::locationsRealpath('../../../') . '/.claude/settings.json', static::$sut . '/.claude/settings.json');
 
     // Change the current working directory to the 'system under test'.
     chdir(static::$sut);

--- a/init.sh
+++ b/init.sh
@@ -521,7 +521,7 @@ process_claude_settings() {
         print prev
       }
     }
-  ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
+  ' "${file}" >"${file}.tmp" && mv "${file}.tmp" "${file}"
 }
 
 process_readme() {

--- a/init.sh
+++ b/init.sh
@@ -508,20 +508,7 @@ process_claude_settings() {
   fi
 
   # Drop a trailing comma left on the final array element after any removals.
-  awk '
-    NR > 1 {
-      if ($0 ~ /^[[:space:]]*\]/) {
-        sub(/,[[:space:]]*$/, "", prev)
-      }
-      print prev
-    }
-    { prev = $0 }
-    END {
-      if (NR > 0) {
-        print prev
-      }
-    }
-  ' "${file}" >"${file}.tmp" && mv "${file}.tmp" "${file}"
+  awk 'NR>1{if($0~/^ *]/)sub(/,$/,"",prev);print prev}{prev=$0}END{if(NR>0)print prev}' "${file}" >"${file}.tmp" && mv "${file}.tmp" "${file}"
 }
 
 process_readme() {

--- a/init.sh
+++ b/init.sh
@@ -483,6 +483,47 @@ remove_schedule() {
 # PROCESSING FUNCTIONS
 #-------------------------------------------------------------------------------
 
+##
+# Trim Claude Code permission rules to match the selected features.
+#
+# The template ships '.claude/settings.json' with the full command allow-list.
+# Rules for features that were not selected are removed so that a generated
+# project only pre-approves commands it can actually run.
+#
+process_claude_settings() {
+  local file=".claude/settings.json"
+  [ -f "${file}" ] || return 0
+
+  local sed_opts
+  sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
+
+  [ "${use_php:-n}" != "y" ] && sed "${sed_opts[@]}" -e '/composer:/d' -e '/phpcs:/d' -e '/phpcbf:/d' -e '/phpstan:/d' -e '/rector:/d' -e '/phpunit:/d' "${file}"
+  [ "${use_shell:-n}" != "y" ] && sed "${sed_opts[@]}" -e '/bats:/d' "${file}"
+  [ "${use_docker:-n}" != "y" ] && sed "${sed_opts[@]}" -e '/docker build:/d' -e '/docker run:/d' "${file}"
+
+  # 'npm' is shared by the NodeJS feature and the documentation site, so keep it
+  # while either is present.
+  if [ "${use_nodejs:-n}" != "y" ] && [ "${use_docs:-n}" != "y" ]; then
+    sed "${sed_opts[@]}" -e '/npm:/d' "${file}"
+  fi
+
+  # Drop a trailing comma left on the final array element after any removals.
+  awk '
+    NR > 1 {
+      if ($0 ~ /^[[:space:]]*\]/) {
+        sub(/,[[:space:]]*$/, "", prev)
+      }
+      print prev
+    }
+    { prev = $0 }
+    END {
+      if (NR > 0) {
+        print prev
+      }
+    }
+  ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
+}
+
 process_readme() {
   mv README.dist.md "README.md" >/dev/null 2>&1 || true
 
@@ -988,6 +1029,8 @@ process_project() {
   [ "${use_docs}" != "y" ] && remove_docs
   [ "${use_test_actions}" != "y" ] && remove_test_actions
   [ "${use_schedule}" != "y" ] && remove_schedule
+
+  process_claude_settings
 
   cleanup_renovate_managers
 


### PR DESCRIPTION
## Summary

Ships a committed `.claude/settings.json` allow-list for Claude Code, derived from the commands documented in `AGENTS.md`, and trims it during `init.sh` to only the commands the selected features can actually run. The `.gitignore` is reworked so the shared settings file is committable while personal overrides in `.claude/settings.local.json` stay local, and the change is documented for both template maintainers and generated-project users.

## Changes

- Added `.claude/settings.json` with a `Bash(...)` allow-list covering `composer`, `phpcs`, `phpcbf`, `phpstan`, `rector`, `phpunit`, `bats`, `npm`, and `docker build`/`docker run`.
- Added `process_claude_settings()` to `init.sh`, called from `process_project()`: removes PHP, shell (`bats`), and Docker rules when the corresponding feature is not selected, keeps `npm` while either the NodeJS feature or the docs site is selected, and strips the trailing comma left on the last array element after trimming so the resulting JSON stays valid.
- Updated `.gitignore` to negate `.claude/` (so the shared `settings.json` is trackable), ignore only `.claude/settings.local.json`, and ignore `/.artifacts/` for temporary agent/developer output.
- Added `.scaffold/tests/phpunit/fixtures/.gitignore` negation for `.claude/` so fixture settings files stay committable even when a developer's global gitignore excludes `.claude` directories.
- Switched `UnitTestCase.php` to `AlexSkrypnyk\File\File::copyIfExists()` to copy the shared `.claude/settings.json` into the system-under-test directory, since the existing bulk copy skips `.claude` entirely to keep personal overrides out.
- Added a data-driven `testInitClaudeSettings()` to `InitTest.php` covering defaults, `--docker`, `--no-php`, and the `npm` retention/removal cases around NodeJS and docs, plus assertions that `settings.local.json` never leaks into a generated project and that the trimmed file stays valid JSON.
- Regenerated the `init` snapshot fixtures (`_baseline`, `docker`, `no_languages`, `nodejs`, `php_command`, `php_script`, `shell`) to include the new `.claude/settings.json` and `.gitignore` output.
- Added `.scaffold/docs/content/ai-integration.mdx`, documenting `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, and `.artifacts` for generated-project users, and added `Claude` to `.scaffold/docs/cspell.json`.
- Added a `Rules for Template Changes` section to `.scaffold/CLAUDE.md` documenting the template-change workflow: run the init suite (not just the repo-root scripts) to validate `init.sh`/template/fixture changes, the Drupal coding standard, the maintainer helper libraries (`alexskrypnyk/file`, `alexskrypnyk/phpunit-helpers`, `alexskrypnyk/snapshot`), regenerating fixtures via `composer update-snapshots`, and the global-gitignore gotcha that silently drops fixture `.claude`/`.artifacts` directories.

## Before / After

```
BEFORE                                          AFTER
+----------------------------------+            +----------------------------------+
| .claude/                         |            | .claude/                         |
|   (untracked, unignored)         |            |   settings.json  (committed)     |
|                                   |   ==>      |   settings.local.json (ignored)  |
| No pre-approved command list;    |            | Pre-approved allow-list trimmed   |
| every agent starts from scratch. |            | to selected features by init.sh. |
+----------------------------------+            +----------------------------------+
| .gitignore: no .artifacts rule   |            | .gitignore: /.artifacts/ ignored, |
|                                   |            | !/.claude/ committable            |
+----------------------------------+            +----------------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add shared Claude Code permissions and keep personal settings local.
- Update `init.sh` to trim PHP, shell, Docker, and npm permissions by selected features while preserving valid JSON.
- Add coverage for feature combinations, JSON validity, fixture handling, and ignored local settings.
- Document AI integration and template-maintenance workflows.
- Regenerate initialization fixtures and snapshots.

## Possibly related

- Could not identify a directly related issue from the available repository context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->