### PR TITLE
[#534] Fixed 'init.sh' not replacing the 'YourProject' application name.

### DIFF
--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/src/app.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/src/app.php
@@ -12,7 +12,7 @@ use YodasHut\App\Command\JokeCommand;
 use YodasHut\App\Command\SayHelloCommand;
 
 // @codeCoverageIgnoreStart
-$application = new Application('YourProject', '@force-crystal-version@');
+$application = new Application('ForceCrystal', '@force-crystal-version@');
 
 $command = new JokeCommand();
 $application->add($command);

--- a/.scaffold/tests/phpunit/fixtures/init/name/src/app.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/src/app.php
@@ -8,8 +8,8 @@
 +use JediTemple\App\Command\SayHelloCommand;
  
  // @codeCoverageIgnoreStart
--$application = new Application('YourProject', '@force-crystal-version@');
-+$application = new Application('YourProject', '@star-forge-version@');
+-$application = new Application('ForceCrystal', '@force-crystal-version@');
++$application = new Application('StarForge', '@star-forge-version@');
  
  $command = new JokeCommand();
  $application->add($command);

--- a/src/app.php
+++ b/src/app.php
@@ -12,7 +12,7 @@ use YourNamespace\App\Command\JokeCommand;
 use YourNamespace\App\Command\SayHelloCommand;
 
 // @codeCoverageIgnoreStart
-$application = new Application('YourProject', '@yourproject-version@');
+$application = new Application('Yourproject', '@yourproject-version@');
 
 $command = new JokeCommand();
 $application->add($command);


### PR DESCRIPTION
Closes #534

## Summary

`src/app.php` passed the literal `YourProject` (capital `P`) as the Symfony `Application` name, but `init.sh`'s token-replacement rules only match `Yourproject` (lowercase `p`) and swap it for `${project_pascalcase}`, so that capital-`P` literal survived every run of `init.sh` untouched. Every project generated from the scaffold therefore reported itself as `YourProject` in `--version` and `--help` output instead of its own name (e.g. `StarForge`). The fix switches the literal to the canonical `Yourproject` token so the existing, tested replacement rule applies, and regenerates the snapshot fixtures that had baked the bug in.

## Changes

- **`src/app.php`:** changed the `Application` name literal from `'YourProject'` to `'Yourproject'` so `init.sh`'s `Yourproject -> ${project_pascalcase}` rule replaces it during generation.
- **`.scaffold/tests/phpunit/fixtures/init/_baseline/src/app.php`:** regenerated snapshot - the baseline fixture now expects the `Application` name to read `ForceCrystal` instead of the unreplaced `YourProject`.
- **`.scaffold/tests/phpunit/fixtures/init/name/src/app.php`:** regenerated snapshot - the `name` scenario's diff fixture now expects `ForceCrystal -> StarForge` instead of `YourProject -> YourProject` (a no-op that masked the bug).

## Screenshots

N/A

## Before / After

```
Before (init.sh run with project name "star-forge")
┌────────────────────────────────────────────────────────────┐
│  src/app.php                                                │
│  $application = new Application('YourProject', ...);        │
│                        │                                    │
│                        │ init.sh replacement rules          │
│                        │ (yourproject, Yourproject, ...)     │
│                        ▼                                    │
│                  no rule matches 'YourProject'              │
│                        │                                    │
│                        ▼                                    │
│  $application = new Application('YourProject', ...);  ✗     │
│                                                               │
│  $ ./star-forge --version                                    │
│  YourProject @star-forge-version@                            │
└────────────────────────────────────────────────────────────┘

After (init.sh run with project name "star-forge")
┌────────────────────────────────────────────────────────────┐
│  src/app.php                                                │
│  $application = new Application('Yourproject', ...);        │
│                        │                                    │
│                        │ init.sh replacement rule           │
│                        │ Yourproject -> ${project_pascalcase}│
│                        ▼                                    │
│  $application = new Application('StarForge', ...);    ✓     │
│                                                               │
│  $ ./star-forge --version                                    │
│  StarForge @star-forge-version@                              │
└────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Changed the Symfony application name token from `YourProject` to `Yourproject` to match `init.sh` replacement rules.
- Regenerated baseline and `name` scenario fixtures to verify configured project names appear in `--version` and `--help` output.
- Resolves `#534`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->