### PR TITLE
[#539] Set PHP 8.4 as CI default and retired PHP 8.2.

### DIFF
--- a/.github/workflows/release-php.yml
+++ b/.github/workflows/release-php.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: 8.3
+          php-version: 8.4
 
       - name: Install dependencies
         run: composer install

--- a/.github/workflows/scaffold-test.yml
+++ b/.github/workflows/scaffold-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: pcov
           ini-values: pcov.directory=.
 

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
         deps: ['normal', 'lowest']
 
     steps:
@@ -71,7 +71,7 @@ jobs:
           composer normalize --dry-run
 
       - name: Check coding standards
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal'
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal'
         run: composer lint
         continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
 
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Check code coverage threshold
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal'
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal'
         run: |
           RATE=$(grep -o 'line-rate="[0-9.]*"' .logs/cobertura.xml | head -1 | tr -cd '0-9.')
           PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -94,7 +94,7 @@ jobs:
           CI_CODE_COVERAGE_THRESHOLD: ${{ vars.CI_CODE_COVERAGE_THRESHOLD || '80' }}
 
       - name: Post coverage summary as PR comment
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal' && github.event_name == 'pull_request'
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal' && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
         with:
           message: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload test results to Codecov
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
         with:
           files: .logs/junit.xml
           fail_ci_if_error: true
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
         with:
           files: .logs/cobertura.xml
           fail_ci_if_error: true
@@ -155,7 +155,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: 8.3
+          php-version: 8.4
 
       - name: Install dependencies
         run: composer install

--- a/.scaffold/docs/content/php/composer.mdx
+++ b/.scaffold/docs/content/php/composer.mdx
@@ -20,7 +20,7 @@ Metadata like name, description, and license.
 Includes maintainer details and URLs for issues and source code.
 
 - **Dependencies**:
-Requires PHP version `>= 8.2`. If using as base for CLI command,
+Requires PHP version `>= 8.3`. If using as base for CLI command,
 `symfony/console` is provided as a dependency as well.
 
 - **Development Dependencies**:

--- a/.scaffold/docs/content/php/linting.mdx
+++ b/.scaffold/docs/content/php/linting.mdx
@@ -68,7 +68,7 @@ the [PHPStan website](https://phpstan.org/config-reference).
 This template provides integration with [Rector](https://getrector.com/), a tool
 that instantly upgrades and refactors the PHP code of your application.
 
-Rector now supports upgrades from PHP 5.3 to 8.2 and major open-source projects
+Rector now supports upgrades from PHP 5.3 to 8.4 and major open-source projects
 like Symfony, PHPUnit, and Doctrine.
 
 Rector helps with automated refactoring when you have code quality you need,

--- a/.scaffold/tests/phpunit/composer.json
+++ b/.scaffold/tests/phpunit/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/alexskrypnyk/scaffold"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "alexskrypnyk/file": "^0.17",
         "alexskrypnyk/phpunit-helpers": "^0.4.1",
         "alexskrypnyk/snapshot": "^0.2.1",

--- a/.scaffold/tests/phpunit/composer.lock
+++ b/.scaffold/tests/phpunit/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b82959f9d91f7376de11407dcce902c",
+    "content-hash": "5ef036ce8739920de5c8d72078e15236",
     "packages": [
         {
             "name": "alexskrypnyk/file",
@@ -3747,7 +3747,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.github/workflows/release-php.yml
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.github/workflows/release-php.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@__HASH__ # __VERSION__
         with:
-          php-version: 8.3
+          php-version: 8.4
 
       - name: Install dependencies
         run: composer install

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.github/workflows/test-php.yml
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.github/workflows/test-php.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
         deps: ['normal', 'lowest']
 
     steps:
@@ -69,7 +69,7 @@ jobs:
           composer normalize --dry-run
 
       - name: Check coding standards
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal'
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal'
         run: composer lint
         continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
 
@@ -78,7 +78,7 @@ jobs:
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
       - name: Check code coverage threshold
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal'
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal'
         run: |
           RATE=$(grep -o 'line-rate="[0-9.]*"' .logs/cobertura.xml | head -1 | tr -cd '0-9.')
           PERCENT=$(awk "BEGIN {printf \"%.2f\", $RATE*100}")
@@ -92,7 +92,7 @@ jobs:
           CI_CODE_COVERAGE_THRESHOLD: ${{ vars.CI_CODE_COVERAGE_THRESHOLD || '80' }}
 
       - name: Post coverage summary as PR comment
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal' && github.event_name == 'pull_request'
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal' && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@__HASH__ # __VERSION__
         with:
           message: |
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload test results to Codecov
         uses: codecov/test-results-action@__HASH__ # __VERSION__
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
         with:
           files: .logs/junit.xml
           fail_ci_if_error: true
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@__HASH__ # __VERSION__
-        if: matrix.php-versions == '8.3' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
+        if: matrix.php-versions == '8.4' && matrix.deps == 'normal' && env.CODECOV_TOKEN != ''
         with:
           files: .logs/cobertura.xml
           fail_ci_if_error: true
@@ -152,7 +152,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@__HASH__ # __VERSION__
         with:
-          php-version: 8.3
+          php-version: 8.4
 
       - name: Install dependencies
         run: composer install

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/AGENTS.md
@@ -109,9 +109,9 @@ composer install
   - Config: `phpstan.neon`
   - Ignores: Untyped iterables in tests/data providers
 
-3. **Rector** - PHP 8.2/8.3 modernization + code quality
+3. **Rector** - PHP 8.3 modernization + code quality
   - Config: `rector.php`
-  - Sets: PHP_82, PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
+  - Sets: PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
     TYPE_DECLARATION
 
 ### Coding Conventions
@@ -152,7 +152,7 @@ Shell script tests use BATS:
 
 GitHub Actions workflows test across:
 
-- PHP versions: 8.2, 8.3
+- PHP versions: 8.3, 8.4
 - Separate jobs: lint, test, coverage upload (Codecov)
 
 Key workflows:

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/rector.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/rector.php
@@ -32,7 +32,7 @@ return RectorConfig::configure()
   ->withPaths([
     __DIR__ . '/**',
   ])
-  ->withPhpSets(php82: TRUE)
+  ->withPhpSets(php83: TRUE)
   ->withPreparedSets(
     deadCode: TRUE,
     codeQuality: TRUE,

--- a/.scaffold/tests/phpunit/fixtures/init/docker/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/AGENTS.md
@@ -112,9 +112,9 @@
 -  - Config: `phpstan.neon`
 -  - Ignores: Untyped iterables in tests/data providers
 -
--3. **Rector** - PHP 8.2/8.3 modernization + code quality
+-3. **Rector** - PHP 8.3 modernization + code quality
 -  - Config: `rector.php`
--  - Sets: PHP_82, PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
+-  - Sets: PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
 -    TYPE_DECLARATION
 -
 -### Coding Conventions
@@ -155,7 +155,7 @@
 -
 -GitHub Actions workflows test across:
 -
--- PHP versions: 8.2, 8.3
+-- PHP versions: 8.3, 8.4
 -- Separate jobs: lint, test, coverage upload (Codecov)
 -
 -Key workflows:

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/AGENTS.md
@@ -100,9 +100,9 @@
 -  - Config: `phpstan.neon`
 -  - Ignores: Untyped iterables in tests/data providers
 -
--3. **Rector** - PHP 8.2/8.3 modernization + code quality
+-3. **Rector** - PHP 8.3 modernization + code quality
 -  - Config: `rector.php`
--  - Sets: PHP_82, PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
+-  - Sets: PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
 -    TYPE_DECLARATION
 -
 -### Coding Conventions
@@ -143,7 +143,7 @@
 -
 -GitHub Actions workflows test across:
 -
--- PHP versions: 8.2, 8.3
+-- PHP versions: 8.3, 8.4
 -- Separate jobs: lint, test, coverage upload (Codecov)
 -
 -Key workflows:

--- a/.scaffold/tests/phpunit/fixtures/init/nodejs/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/nodejs/AGENTS.md
@@ -100,9 +100,9 @@
 -  - Config: `phpstan.neon`
 -  - Ignores: Untyped iterables in tests/data providers
 -
--3. **Rector** - PHP 8.2/8.3 modernization + code quality
+-3. **Rector** - PHP 8.3 modernization + code quality
 -  - Config: `rector.php`
--  - Sets: PHP_82, PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
+-  - Sets: PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
 -    TYPE_DECLARATION
 -
 -### Coding Conventions
@@ -143,7 +143,7 @@
 -
 -GitHub Actions workflows test across:
 -
--- PHP versions: 8.2, 8.3
+-- PHP versions: 8.3, 8.4
 -- Separate jobs: lint, test, coverage upload (Codecov)
 -
 -Key workflows:

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/.github/workflows/test-php.yml
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/.github/workflows/test-php.yml
@@ -21,7 +21,7 @@
 -      - name: Setup PHP
 -        uses: shivammathur/setup-php@__HASH__ # __VERSION__
 -        with:
--          php-version: 8.3
+-          php-version: 8.4
 -
 -      - name: Install dependencies
 -        run: composer install

--- a/.scaffold/tests/phpunit/fixtures/init/shell/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/shell/AGENTS.md
@@ -100,9 +100,9 @@
 -  - Config: `phpstan.neon`
 -  - Ignores: Untyped iterables in tests/data providers
 -
--3. **Rector** - PHP 8.2/8.3 modernization + code quality
+-3. **Rector** - PHP 8.3 modernization + code quality
 -  - Config: `rector.php`
--  - Sets: PHP_82, PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
+-  - Sets: PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
 -    TYPE_DECLARATION
 -
 -### Coding Conventions
@@ -143,7 +143,7 @@
 -
 -GitHub Actions workflows test across:
 -
--- PHP versions: 8.2, 8.3
+-- PHP versions: 8.3, 8.4
 -- Separate jobs: lint, test, coverage upload (Codecov)
 -
 -Key workflows:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,9 +161,9 @@ composer install
   - Config: `phpstan.neon`
   - Ignores: Untyped iterables in tests/data providers
 
-3. **Rector** - PHP 8.2/8.3 modernization + code quality
+3. **Rector** - PHP 8.3 modernization + code quality
   - Config: `rector.php`
-  - Sets: PHP_82, PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
+  - Sets: PHP_83, CODE_QUALITY, CODING_STYLE, DEAD_CODE,
     TYPE_DECLARATION
 
 ### Coding Conventions
@@ -208,7 +208,7 @@ Shell script tests use BATS:
 
 GitHub Actions workflows test across:
 
-- PHP versions: 8.2, 8.3
+- PHP versions: 8.3, 8.4
 - Separate jobs: lint, test, coverage upload (Codecov)
 
 Key workflows:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/yournamespace/yourproject"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "symfony/console": "^7.4.14"
     },
     "require-dev": {

--- a/rector.php
+++ b/rector.php
@@ -32,7 +32,7 @@ return RectorConfig::configure()
   ->withPaths([
     __DIR__ . '/**',
   ])
-  ->withPhpSets(php82: TRUE)
+  ->withPhpSets(php83: TRUE)
   ->withPreparedSets(
     deadCode: TRUE,
     codeQuality: TRUE,


### PR DESCRIPTION
Closes #539

## Summary

Promotes PHP 8.4 to the default CI version and retires PHP 8.2 as a supported version across the scaffold template and its maintenance test harness. The singleton CI gates (lint, coverage threshold, PR coverage comment, Codecov uploads) and the PHAR/release build jobs now run against PHP 8.4 instead of PHP 8.3, the test matrix drops `8.2`, the minimum supported PHP version rises to `>=8.3` everywhere it is declared, and Rector's modernization target moves from `php82` to `php83`. Documentation and the `.scaffold/tests/phpunit/fixtures/init/**` snapshots are regenerated to match.

## Changes

- **CI default version bumped to PHP 8.4**: in `.github/workflows/test-php.yml` the five singleton-job gates (`lint`, coverage threshold, PR coverage comment, Codecov test-results upload, Codecov coverage upload) moved their `matrix.php-versions == '8.3'` condition to `== '8.4'`, and the `build-php` PHAR job's `php-version` moved from `8.3` to `8.4`; `.github/workflows/release-php.yml` and `.github/workflows/scaffold-test.yml` also moved their `php-version` from `8.3` to `8.4`.
- **PHP 8.2 retired**: dropped `8.2` from the `test-php.yml` matrix (now `['8.3', '8.4', '8.5']`), raised `composer.json` `require.php` from `>=8.2` to `>=8.3`, and updated `.scaffold/docs/content/php/composer.mdx` to say `>= 8.3`.
- **Rector modernization target bumped**: `rector.php` now calls `withPhpSets(php83: TRUE)` instead of `php82: TRUE`; updated `AGENTS.md`'s Rector description (`PHP_82, PHP_83` sets → `PHP_83`) and its CI matrix line (`PHP versions: 8.2, 8.3` → `8.3, 8.4`), and `.scaffold/docs/content/php/linting.mdx` ("PHP 5.3 to 8.2" → "5.3 to 8.4"). Rector produced zero source rewrites since the codebase was already PHP 8.3-clean.
- **Maintenance test harness**: `.scaffold/tests/phpunit/composer.json` `require.php` raised from `>=8.2` to `>=8.3`, with `composer.lock` content-hash refreshed to match (no dependency version changes).
- **Regenerated fixtures**: regenerated the `.scaffold/tests/phpunit/fixtures/init/**` snapshots (`_baseline` plus the `docker`, `no_languages`, `nodejs`, `php_script`, and `shell` variants) via `composer update-snapshots` so they reflect the CI and Rector changes above.

## Before / After

```
Before:
┌────────────────────────────────────┐
│ CI matrix:   [8.2, 8.3*, 8.4, 8.5] │
│ Minimum PHP: >=8.2                 │
│ Rector set:  php82                 │
└────────────────────────────────────┘
                  │
                  ▼
After:
┌────────────────────────────────────┐
│ CI matrix:   [8.3, 8.4*, 8.5]      │
│ Minimum PHP: >=8.3                 │
│ Rector set:  php83                 │
└────────────────────────────────────┘

* = default version used by the singleton CI jobs (lint, coverage gate,
    PR coverage comment, Codecov uploads) and the PHAR/release build job.
```
