### PR TITLE
[#537] Fixed mangled attribution footer in generated README.

### DIFF
--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/README.md
@@ -93,4 +93,4 @@ To pull the latest infrastructure from the template into this project, ask
 Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
 
 ---
-_This repository was created using the [force-crystal](https://getforce-crystal.dev/) project template_
+_This repository was created using the [Scaffold](https://getscaffold.dev/) project template_

--- a/.scaffold/tests/phpunit/fixtures/init/name/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/README.md
@@ -73,9 +73,3 @@
  
      npm ci --prefix tests/bats
      ./tests/bats/node_modules/.bin/bats tests/bats
-@@ -93,4 +93,4 @@
- Claude Code to "update scaffold" - see [`AGENTS.md`](AGENTS.md) for details.
- 
- ---
--_This repository was created using the [force-crystal](https://getforce-crystal.dev/) project template_
-+_This repository was created using the [star-forge](https://getstar-forge.dev/) project template_

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -161,6 +161,31 @@ final class InitTest extends UnitTestCase {
   }
 
   /**
+   * The initialised project keeps the Scaffold attribution footer intact.
+   *
+   * The bulk `scaffold` -> project rewrite in init.sh would otherwise
+   * mangle the README footer link text and domain into a project-named URL
+   * that does not exist. The phrase is token-protected, so a regression must
+   * fail loudly rather than being silently re-baselined.
+   */
+  public function testInitPreservesAttributionFooter(): void {
+    self::$fixtures = NULL;
+
+    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', [
+      '--namespace=AcmeApp',
+      '--name=acme-app',
+      '--author=Jane Doe',
+    ]);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains('Initialization complete.');
+
+    $readme = (string) file_get_contents(self::$sut . DIRECTORY_SEPARATOR . 'README.md');
+    $this->assertStringContainsString('_This repository was created using the [Scaffold](https://getscaffold.dev/) project template_', $readme);
+    $this->assertStringNotContainsString('getacme-app.dev', $readme);
+  }
+
+  /**
    * A project generated with Actions linting must pass the zizmor audit.
    *
    * Mirrors the audit the shipped "Test Actions" workflow runs, using the

--- a/init.sh
+++ b/init.sh
@@ -584,10 +584,15 @@ process_internal() {
   replace_string_content "Alex Skrypnyk" "${author}"
 
   remove_string_content "Generic project scaffold template"
-  replace_string_content "https://getscaffold.dev/ project scaffold template" "__ATTRIBUTION__"
+
+  # Shield the attribution footer from the bulk rename below so its link
+  # text and domain keep naming Scaffold. The needle starts after the "["
+  # because the helper matches via grep/sed regex, where a leading
+  # "[Scaffold]" is a character class that never matches the literal text.
+  replace_string_content "Scaffold](https://getscaffold.dev/) project template" "__ATTRIBUTION__"
   replace_string_content "Scaffold" "${project}"
   replace_string_content "scaffold" "${project}"
-  replace_string_content "__ATTRIBUTION__" "https://getscaffold.dev/ project scaffold template"
+  replace_string_content "__ATTRIBUTION__" "Scaffold](https://getscaffold.dev/) project template"
 
   restore_skill_references
 

--- a/init.sh
+++ b/init.sh
@@ -586,10 +586,11 @@ process_internal() {
   remove_string_content "Generic project scaffold template"
 
   # Shield the attribution footer from the bulk rename below so its link
-  # text and domain keep naming Scaffold. The needle starts after the "["
-  # because the helper matches via grep/sed regex, where a leading
-  # "[Scaffold]" is a character class that never matches the literal text.
-  replace_string_content "Scaffold](https://getscaffold.dev/) project template" "__ATTRIBUTION__"
+  # text and domain keep naming Scaffold. The needle is a grep/sed regex:
+  # it starts after the "[" (a leading "[Scaffold]" would be a character
+  # class) and escapes the "." so it matches the literal domain. The restore
+  # value is a plain replacement, so it needs neither.
+  replace_string_content "Scaffold](https://getscaffold\.dev/) project template" "__ATTRIBUTION__"
   replace_string_content "Scaffold" "${project}"
   replace_string_content "scaffold" "${project}"
   replace_string_content "__ATTRIBUTION__" "Scaffold](https://getscaffold.dev/) project template"


### PR DESCRIPTION
Closes #537

## Summary

`init.sh` protects the README attribution footer from the bulk `Scaffold`/`scaffold` -> project-name rename by swapping it for an `__ATTRIBUTION__` token before the rename and restoring it afterward. The protect needle was stale (`https://getscaffold.dev/ project scaffold template`) and never matched the actual footer text (`_This repository was created using the [Scaffold](https://getscaffold.dev/) project template_`), so the rename ran straight over the unprotected footer and produced a nonexistent `get<project>.dev` domain, for example `[skilltest](https://getskilltest.dev/)`.

## Changes

- Replaced the stale protect/restore needle in `init.sh` with the actual footer phrase, made regex-safe for the `grep`/`sed`-based helper: the needle starts after the `[` (a leading `[Scaffold]` is a regex character class that would never match), and the protect side escapes the `.` in `getscaffold\.dev` while the restore side stays a literal replacement.
- Added `testInitPreservesAttributionFooter()` to `.scaffold/tests/phpunit/src/InitTest.php`, modeled on the existing `testInitPreservesUpdateSkillReferences()`, asserting the generated `README.md` keeps the verbatim `[Scaffold](https://getscaffold.dev/)` footer and never contains a mangled `getacme-app.dev`.
- Regenerated the init snapshot fixtures (`_baseline`, `name`), which had enshrined the mangled footer; they now carry the correct footer text.

## Screenshots

N/A

## Before / After

```
BEFORE — protect needle is stale, never matches the real footer
┌──────────────────────────────────────────────────────────────────────┐
│ 1. protect  needle: "https://getscaffold.dev/ project scaffold        │
│             template"                                                 │
│             actual: "...the [Scaffold](https://getscaffold.dev/)     │
│             project template_"                                        │
│             → no match, footer left unprotected                      │
│ 2. rename   Scaffold/scaffold → ${project}   (footer rewritten too)   │
│ 3. restore  "__ATTRIBUTION__" → stale phrase (no-op, nothing to find) │
└──────────────────────────────────────────────────────────────────────┘
   result: [skilltest](https://getskilltest.dev/)   ✗ domain doesn't exist

AFTER — protect needle matches the real footer
┌──────────────────────────────────────────────────────────────────────┐
│ 1. protect  needle: "Scaffold](https://getscaffold\.dev/) project     │
│             template"                                                 │
│             → matches, footer swapped for the __ATTRIBUTION__ token   │
│ 2. rename   Scaffold/scaffold → ${project}   (token is inert)         │
│ 3. restore  "__ATTRIBUTION__" → "Scaffold](https://getscaffold.dev/)  │
│             project template"                                         │
└──────────────────────────────────────────────────────────────────────┘
   result: [Scaffold](https://getscaffold.dev/)   ✓ correct footer
```
