### PR TITLE
[#541] Enabled 'init.sh' to bootstrap the template when piped from curl into an empty directory.

### DIFF
--- a/.github/workflows/scaffold-release-docs.yml
+++ b/.github/workflows/scaffold-release-docs.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Bake version into init.sh
         working-directory: ${{ github.workspace }}
         run: |
-          sed -i "s|^SCAFFOLD_VERSION=\"dev\"|SCAFFOLD_VERSION=\"${RELEASE_VERSION}\"|" init.sh
+          escaped=$(printf '%s' "${RELEASE_VERSION}" | sed -e 's/[\\&|]/\\&/g')
+          sed -i "s|^SCAFFOLD_VERSION=\"dev\"|SCAFFOLD_VERSION=\"${escaped}\"|" init.sh
           grep '^SCAFFOLD_VERSION=' init.sh
 
       - name: Build documentation site

--- a/.github/workflows/scaffold-release-docs.yml
+++ b/.github/workflows/scaffold-release-docs.yml
@@ -57,6 +57,12 @@ jobs:
           echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
           echo "Release version: $version"
 
+      - name: Bake version into init.sh
+        working-directory: ${{ github.workspace }}
+        run: |
+          sed -i "s|^SCAFFOLD_VERSION=\"dev\"|SCAFFOLD_VERSION=\"${RELEASE_VERSION}\"|" init.sh
+          grep '^SCAFFOLD_VERSION=' init.sh
+
       - name: Build documentation site
         run: npm run build
         working-directory: '${{ github.workspace }}/.scaffold/docs'

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -29,6 +29,10 @@ The initialization script performs three main operations:
 
 3. **Cleanup** - Removes `.scaffold/` directory and template-specific files
 
+### Curl bootstrap
+
+When `init.sh` runs without the template present (for example fetched and piped straight from `curl` into an empty directory), it downloads the Scaffold archive into the current directory, extracts it with `tar --strip-components=1`, and re-executes the on-disk copy so init proceeds normally. Presence of the `.scaffold/` directory is the sentinel for "template already here". The archive URL is resolved in precedence order: the `SCAFFOLD_ARCHIVE_URL` environment variable, the `--ref=<tag|branch|commit>` option, then the latest GitHub release (falling back to the `main` branch). The re-exec reconnects stdin to `/dev/tty` in interactive mode so prompts work despite the pipe, and bootstrapping refuses a non-empty directory. The curl-bootstrap PHPUnit tests (`testInitViaCurlBootstrapsIntoEmptyDir`, `testInitViaCurlBootstrapRefusesNonEmptyDir`) stay off the network by pointing `SCAFFOLD_ARCHIVE_URL` at a local `file://` tarball built from the SUT.
+
 ### Token System for Conditional Content
 
 Content blocks can be conditionally included/excluded using special tokens:

--- a/.scaffold/docs/.gitignore
+++ b/.scaffold/docs/.gitignore
@@ -10,6 +10,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+/static/init.sh
 
 # Misc
 .env.local

--- a/.scaffold/docs/content/README.mdx
+++ b/.scaffold/docs/content/README.mdx
@@ -19,10 +19,14 @@ projects, so you can focus on the important stuff.
 
 ## Quick start
 
-1. Download the latest release from [GitHub](https://github.com/AlexSkrypnyk/scaffold/releases/latest)
-2. Run `./init.sh` to replace `yournamespace`, `yourproject`, `Your Name` and
-   other strings with your own and choose the features.
-3. Commit and push the changes to your repository.
+The quickest way to start is a single command in a new **empty directory** - it downloads Scaffold and initializes the project in place, with no manual download or checkout:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
+  bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
+```
+
+Piping with no options prompts you interactively for every choice; pass options (as above) to run unattended. The latest release is used by default - add `--ref=<tag|branch|commit>` to pin a specific version. Then commit and push the result to your repository.
 
 <AsciinemaPlayer
   src="/img/init.cast"
@@ -32,11 +36,12 @@ projects, so you can focus on the important stuff.
   terminalLineHeight={1.1}
 />
 
-To set up without prompts, pass options instead (useful for automation):
+### Alternative: start from a checkout
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
-  bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
-```
+Prefer to work from a local copy first?
+
+1. Download the latest release from [GitHub](https://github.com/AlexSkrypnyk/scaffold/releases/latest).
+2. Run `./init.sh` to replace `yournamespace`, `yourproject`, `Your Name` and other strings with your own and choose the features.
+3. Commit and push the changes to your repository.
 
 Run `./init.sh --help` for all options.

--- a/.scaffold/docs/content/README.mdx
+++ b/.scaffold/docs/content/README.mdx
@@ -22,7 +22,7 @@ projects, so you can focus on the important stuff.
 The quickest way to start is a single command in a new **empty directory** - it downloads Scaffold and initializes the project in place, with no manual download or checkout:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
+curl -fsSL https://getscaffold.dev/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 

--- a/.scaffold/docs/content/README.mdx
+++ b/.scaffold/docs/content/README.mdx
@@ -19,14 +19,20 @@ projects, so you can focus on the important stuff.
 
 ## Quick start
 
-The quickest way to start is a single command in a new **empty directory** - it downloads Scaffold and initializes the project in place, with no manual download or checkout:
+The quickest way to start is a single command in a new **empty directory** - it downloads Scaffold and then prompts you for the project details:
+
+```bash
+curl -fsSL https://getscaffold.dev/init.sh | bash
+```
+
+To run unattended - for automation and AI agents - pass the details as options instead of answering prompts:
 
 ```bash
 curl -fsSL https://getscaffold.dev/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-Piping with no options prompts you interactively for every choice; pass options (as above) to run unattended. The latest release is used by default - add `--ref=<tag|branch|commit>` to pin a specific version. Then commit and push the result to your repository.
+The latest release is used by default - add `--ref=<tag|branch|commit>` to pin a specific version. Then commit and push the result to your repository.
 
 <AsciinemaPlayer
   src="/img/init.cast"

--- a/.scaffold/docs/content/README.mdx
+++ b/.scaffold/docs/content/README.mdx
@@ -32,7 +32,7 @@ curl -fsSL https://getscaffold.dev/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-The latest release is used by default - add `--ref=<tag|branch|commit>` to pin a specific version. Then commit and push the result to your repository.
+The latest release is used by default; to pin a specific tag, branch, or commit, pass `--ref` to the script after `bash -s --` (for example `bash -s -- --ref=1.2.3`). Then commit and push the result to your repository.
 
 <AsciinemaPlayer
   src="/img/init.cast"

--- a/.scaffold/docs/package.json
+++ b/.scaffold/docs/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "copy-init": "cp ../../init.sh static/init.sh",
+    "prestart": "npm run copy-init",
     "start": "docusaurus start",
+    "prebuild": "npm run copy-init",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -621,3 +621,64 @@ SETTINGS
   assert_success
   assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz"
 }
+
+create_template_tarball() {
+  local out="${1}"
+  local with_scaffold="${2:-1}"
+  local src="${BATS_TEST_TMPDIR}/tpl-src"
+  rm -rf "${src}"
+  mkdir -p "${src}/pkg"
+  touch "${src}/pkg/composer.json"
+  if [ "${with_scaffold}" = "1" ]; then
+    mkdir -p "${src}/pkg/.scaffold"
+    touch "${src}/pkg/.scaffold/README.md"
+  fi
+  tar -czf "${out}" -C "${src}" pkg
+}
+
+@test "fetch_and_stage_template promotes a valid archive" {
+  local archive="${BATS_TEST_TMPDIR}/valid.tar.gz"
+  create_template_tarball "${archive}" 1
+
+  local target="${BATS_TEST_TMPDIR}/valid-target"
+  mkdir -p "${target}"
+
+  pushd "${target}" >/dev/null || return 1
+  run fetch_and_stage_template "file://${archive}"
+  popd >/dev/null || return 1
+
+  assert_success
+  assert_dir_exists "${target}/.scaffold"
+  assert_file_exists "${target}/composer.json"
+  assert_dir_not_exists "${target}/.scaffold-bootstrap"
+}
+
+@test "fetch_and_stage_template rejects an archive without .scaffold" {
+  local archive="${BATS_TEST_TMPDIR}/invalid.tar.gz"
+  create_template_tarball "${archive}" 0
+
+  local target="${BATS_TEST_TMPDIR}/invalid-target"
+  mkdir -p "${target}"
+
+  pushd "${target}" >/dev/null || return 1
+  run fetch_and_stage_template "file://${archive}"
+  popd >/dev/null || return 1
+
+  assert_failure
+  assert_output_contains "not a Scaffold template"
+  assert_dir_not_exists "${target}/.scaffold-bootstrap"
+  assert_file_not_exists "${target}/composer.json"
+}
+
+@test "fetch_and_stage_template fails when the download fails" {
+  local target="${BATS_TEST_TMPDIR}/download-fail-target"
+  mkdir -p "${target}"
+
+  pushd "${target}" >/dev/null || return 1
+  run fetch_and_stage_template "file://${BATS_TEST_TMPDIR}/missing.tar.gz"
+  popd >/dev/null || return 1
+
+  assert_failure
+  assert_output_contains "failed to download"
+  assert_dir_not_exists "${target}/.scaffold-bootstrap"
+}

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -529,3 +529,87 @@ SETTINGS
   assert_success
   assert_file_not_exists "${tmpdir}/.claude/settings.json"
 }
+
+@test "parse_args --ref sets the bootstrap ref" {
+  parse_args --ref=1.2.3
+  assert_equal "${archive_ref}" "1.2.3"
+}
+
+@test "template_present detects the .scaffold directory" {
+  local tmpdir="${BATS_TEST_TMPDIR}/template_present"
+  mkdir -p "${tmpdir}/.scaffold"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  run template_present
+  popd >/dev/null || return 1
+
+  assert_success
+}
+
+@test "template_present fails when .scaffold is absent" {
+  local tmpdir="${BATS_TEST_TMPDIR}/template_absent"
+  mkdir -p "${tmpdir}"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  run template_present
+  popd >/dev/null || return 1
+
+  assert_failure
+}
+
+@test "dir_is_empty is true for an empty directory" {
+  local tmpdir="${BATS_TEST_TMPDIR}/empty"
+  mkdir -p "${tmpdir}"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  run dir_is_empty
+  popd >/dev/null || return 1
+
+  assert_success
+}
+
+@test "dir_is_empty is false when a dotfile is present" {
+  local tmpdir="${BATS_TEST_TMPDIR}/dotfile"
+  mkdir -p "${tmpdir}"
+  touch "${tmpdir}/.hidden"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  run dir_is_empty
+  popd >/dev/null || return 1
+
+  assert_failure
+}
+
+@test "resolve_archive_url prefers SCAFFOLD_ARCHIVE_URL" {
+  SCAFFOLD_ARCHIVE_URL="file:///tmp/local.tar.gz"
+  archive_ref="1.2.3"
+  run resolve_archive_url
+  assert_success
+  assert_equal "${output}" "file:///tmp/local.tar.gz"
+}
+
+@test "resolve_archive_url builds an archive URL from --ref" {
+  SCAFFOLD_ARCHIVE_URL=""
+  archive_ref="feature-x"
+  run resolve_archive_url
+  assert_success
+  assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/feature-x.tar.gz"
+}
+
+@test "resolve_archive_url uses the latest release tag by default" {
+  SCAFFOLD_ARCHIVE_URL=""
+  archive_ref=""
+  curl() { echo '{"tag_name": "9.9.9"}'; }
+  run resolve_archive_url
+  assert_success
+  assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/refs/tags/9.9.9.tar.gz"
+}
+
+@test "resolve_archive_url falls back to main when no release is found" {
+  SCAFFOLD_ARCHIVE_URL=""
+  archive_ref=""
+  curl() { return 1; }
+  run resolve_archive_url
+  assert_success
+  assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz"
+}

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -308,6 +308,12 @@ WORKFLOW
   assert_output_contains "Usage: ./init.sh"
 }
 
+@test "parse_args prints the version for --version" {
+  run parse_args --version
+  assert_success
+  assert_output "dev"
+}
+
 @test "require_identity fails when identity is missing" {
   run require_identity
   assert_failure

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -3,8 +3,10 @@
 # Unit tests for init.sh.
 #
 # Variables under test are assigned by the sourced init.sh, which shellcheck
-# does not follow, so disable "unassigned variable" (SC2154) here.
-# shellcheck disable=SC2034,SC2154
+# does not follow, so disable "unassigned variable" (SC2154) here. The 'curl'
+# mocks are invoked indirectly by init.sh functions under 'run' and cannot be
+# traced statically, so "function never invoked" (SC2329) is disabled too.
+# shellcheck disable=SC2034,SC2154,SC2329
 
 load _helper
 load "../../../init.sh"

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -132,6 +132,87 @@ final class InitTest extends UnitTestCase {
   }
 
   /**
+   * The script bootstraps the template when piped into an empty directory.
+   *
+   * With no template present, init.sh downloads and extracts the Scaffold into
+   * the current directory, then initialises it. The archive is injected via
+   * SCAFFOLD_ARCHIVE_URL so the test never reaches the network.
+   */
+  public function testInitViaCurlBootstrapsIntoEmptyDir(): void {
+    self::$fixtures = NULL;
+
+    // Build a template archive from the pristine SUT copy. GitHub archives nest
+    // everything under a top-level directory, so archive the SUT under its own
+    // basename and strip that component on extraction, exactly as init.sh does
+    // against a real GitHub tarball.
+    $archive = self::$tmp . DIRECTORY_SEPARATOR . 'scaffold.tar.gz';
+    $this->processRun('tar', ['-czf', $archive, '-C', dirname(self::$sut), basename(self::$sut)]);
+    $this->assertProcessSuccessful();
+
+    $target = File::mkdir(self::$tmp . DIRECTORY_SEPARATOR . 'bootstrap-target');
+
+    $url = 'file://' . self::$sut . DIRECTORY_SEPARATOR . 'init.sh';
+    $script = sprintf(
+      'set -o pipefail; curl -fsSL %s | bash -s -- --namespace=CurlNs --name=curl-proj --author=%s',
+      escapeshellarg($url),
+      escapeshellarg('Curl Author'),
+    );
+
+    $this->processCwd = $target;
+    $this->processRun('bash', ['-c', $script], [], ['SCAFFOLD_ARCHIVE_URL' => 'file://' . $archive]);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains('Downloading Scaffold from');
+    $this->assertProcessOutputContains('Initialization complete.');
+
+    // The template was downloaded and initialised in the target directory.
+    $composer_path = $target . DIRECTORY_SEPARATOR . 'composer.json';
+    $this->assertFileExists($composer_path);
+    $composer = (string) file_get_contents($composer_path);
+    $this->assertStringContainsString('CurlNs', $composer);
+    $this->assertStringNotContainsString('YourNamespace', $composer);
+
+    // The downloaded archive and the template marker are cleaned up by init.
+    $this->assertFileDoesNotExist($target . DIRECTORY_SEPARATOR . 'scaffold.tar.gz');
+    $this->assertDirectoryDoesNotExist($target . DIRECTORY_SEPARATOR . '.scaffold');
+  }
+
+  /**
+   * Bootstrapping refuses to run in a directory that already has files.
+   *
+   * A non-empty current directory must abort before anything is downloaded, so
+   * pre-existing files are never clobbered.
+   */
+  public function testInitViaCurlBootstrapRefusesNonEmptyDir(): void {
+    self::$fixtures = NULL;
+
+    $archive = self::$tmp . DIRECTORY_SEPARATOR . 'scaffold.tar.gz';
+    $this->processRun('tar', ['-czf', $archive, '-C', dirname(self::$sut), basename(self::$sut)]);
+    $this->assertProcessSuccessful();
+
+    $target = File::mkdir(self::$tmp . DIRECTORY_SEPARATOR . 'nonempty-target');
+    File::dump($target . DIRECTORY_SEPARATOR . 'keep.txt', 'existing');
+
+    $url = 'file://' . self::$sut . DIRECTORY_SEPARATOR . 'init.sh';
+    $script = sprintf(
+      'set -o pipefail; curl -fsSL %s | bash -s -- --namespace=CurlNs --name=curl-proj --author=%s',
+      escapeshellarg($url),
+      escapeshellarg('Curl Author'),
+    );
+
+    $this->processCwd = $target;
+    $this->processRun('bash', ['-c', $script], [], ['SCAFFOLD_ARCHIVE_URL' => 'file://' . $archive]);
+
+    $this->assertProcessFailed();
+    $this->assertProcessErrorOutputContains('current directory is not empty');
+
+    // The stray file is untouched and no template was extracted.
+    $this->assertFileExists($target . DIRECTORY_SEPARATOR . 'keep.txt');
+    $this->assertDirectoryDoesNotExist($target . DIRECTORY_SEPARATOR . '.scaffold');
+    $this->assertFileDoesNotExist($target . DIRECTORY_SEPARATOR . 'composer.json');
+  }
+
+  /**
    * The initialised project keeps the updater skill pointing upstream.
    *
    * The bulk `scaffold` -> project rewrite in init.sh would otherwise

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -213,6 +213,39 @@ final class InitTest extends UnitTestCase {
   }
 
   /**
+   * Piping with no options bootstraps, then reaches interactive prompting.
+   *
+   * `curl ... | bash` with no options must download and extract the template
+   * and then re-run to prompt the user. The test environment has no terminal,
+   * so the prompt has nothing to read and the run aborts cleanly - proving the
+   * bootstrap completed and control reached the interactive collector (a real
+   * user with a terminal answers the prompts instead).
+   */
+  public function testInitViaCurlBootstrapsThenPromptsWithoutOptions(): void {
+    self::$fixtures = NULL;
+
+    $archive = self::$tmp . DIRECTORY_SEPARATOR . 'scaffold.tar.gz';
+    $this->processRun('tar', ['-czf', $archive, '-C', dirname(self::$sut), basename(self::$sut)]);
+    $this->assertProcessSuccessful();
+
+    $target = File::mkdir(self::$tmp . DIRECTORY_SEPARATOR . 'prompt-target');
+
+    $url = 'file://' . self::$sut . DIRECTORY_SEPARATOR . 'init.sh';
+    $script = sprintf('set -o pipefail; curl -fsSL %s | bash', escapeshellarg($url));
+
+    $this->processCwd = $target;
+    $this->processRun('bash', ['-c', $script], [], ['SCAFFOLD_ARCHIVE_URL' => 'file://' . $archive]);
+
+    // No terminal to read prompts from, so the interactive run aborts cleanly.
+    $this->assertProcessFailed();
+    $this->assertProcessErrorOutputContains('No input available');
+
+    // The template was still downloaded and extracted before prompting.
+    $this->assertFileExists($target . DIRECTORY_SEPARATOR . 'composer.json');
+    $this->assertDirectoryExists($target . DIRECTORY_SEPARATOR . 'src');
+  }
+
+  /**
    * The initialised project keeps the updater skill pointing upstream.
    *
    * The bulk `scaffold` -> project rewrite in init.sh would otherwise

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -246,6 +246,44 @@ final class InitTest extends UnitTestCase {
   }
 
   /**
+   * An archive without a '.scaffold' leaves the target directory clean.
+   *
+   * The download is staged and validated before anything is promoted, so an
+   * archive that is not a Scaffold (or a partial extraction) must abort without
+   * leaving debris that would trip the empty-directory guard on a retry.
+   */
+  public function testInitViaCurlBootstrapCleansUpInvalidArchive(): void {
+    self::$fixtures = NULL;
+
+    // An archive that extracts to content but has no '.scaffold' directory.
+    $fake = File::mkdir(self::$tmp . DIRECTORY_SEPARATOR . 'not-a-scaffold');
+    File::dump($fake . DIRECTORY_SEPARATOR . 'hello.txt', 'hi');
+    $archive = self::$tmp . DIRECTORY_SEPARATOR . 'not-scaffold.tar.gz';
+    $this->processRun('tar', ['-czf', $archive, '-C', dirname($fake), basename($fake)]);
+    $this->assertProcessSuccessful();
+
+    $target = File::mkdir(self::$tmp . DIRECTORY_SEPARATOR . 'invalid-target');
+
+    $url = 'file://' . self::$sut . DIRECTORY_SEPARATOR . 'init.sh';
+    $script = sprintf(
+      'set -o pipefail; curl -fsSL %s | bash -s -- --namespace=CurlNs --name=curl-proj --author=%s',
+      escapeshellarg($url),
+      escapeshellarg('Curl Author'),
+    );
+
+    $this->processCwd = $target;
+    $this->processRun('bash', ['-c', $script], [], ['SCAFFOLD_ARCHIVE_URL' => 'file://' . $archive]);
+
+    $this->assertProcessFailed();
+    $this->assertProcessErrorOutputContains('not a Scaffold template');
+
+    // No staging directory and no extracted debris remain in the target.
+    $this->assertDirectoryDoesNotExist($target . DIRECTORY_SEPARATOR . '.scaffold-bootstrap');
+    $this->assertFileDoesNotExist($target . DIRECTORY_SEPARATOR . 'hello.txt');
+    $this->assertFileDoesNotExist($target . DIRECTORY_SEPARATOR . 'composer.json');
+  }
+
+  /**
    * The initialised project keeps the updater skill pointing upstream.
    *
    * The bulk `scaffold` -> project rewrite in init.sh would otherwise

--- a/README.md
+++ b/README.md
@@ -87,14 +87,20 @@ Pass options instead of answering prompts to initialise without any interaction 
 ./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-The same works as a one-liner straight from getscaffold.dev, with no prior checkout - run it in an **empty directory** and the script downloads the Scaffold into the current directory before initialising it:
+The same works as a one-liner straight from getscaffold.dev, with no prior checkout - run it in an **empty directory** and the script downloads the Scaffold into the current directory, then prompts you for the details:
+
+```bash
+curl -fsSL https://getscaffold.dev/init.sh | bash
+```
+
+To stay fully unattended, pass the details as options instead:
 
 ```bash
 curl -fsSL https://getscaffold.dev/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-Piping with no options prompts interactively for every choice. The latest release is used by default; pass `--ref=<tag|branch|commit>` to pin a specific version. Run `./init.sh --help` for the full list of options.
+The latest release is used by default; pass `--ref=<tag|branch|commit>` to pin a specific version. Run `./init.sh --help` for the full list of options.
 
 ## Updating a generated project
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ Pass options instead of answering prompts to initialise without any interaction 
 ./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-The same works as a one-liner straight from GitHub:
+The same works as a one-liner straight from GitHub, with no prior checkout - run it in an **empty directory** and the script downloads the Scaffold into the current directory before initialising it:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-Run `./init.sh --help` for the full list of options.
+Piping with no options prompts interactively for every choice. The latest release is used by default; pass `--ref=<tag|branch|commit>` to pin a specific version. Run `./init.sh --help` for the full list of options.
 
 ## Updating a generated project
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ curl -fsSL https://getscaffold.dev/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-The latest release is used by default; pass `--ref=<tag|branch|commit>` to pin a specific version. Run `./init.sh --help` for the full list of options.
+The latest release is used by default; to pin a specific tag, branch, or commit, pass `--ref` to the script after `bash -s --` (for example `bash -s -- --ref=1.2.3`). Run `./init.sh --help` for the full list of options.
 
 ## Updating a generated project
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Pass options instead of answering prompts to initialise without any interaction 
 ./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 
-The same works as a one-liner straight from GitHub, with no prior checkout - run it in an **empty directory** and the script downloads the Scaffold into the current directory before initialising it:
+The same works as a one-liner straight from getscaffold.dev, with no prior checkout - run it in an **empty directory** and the script downloads the Scaffold into the current directory before initialising it:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
+curl -fsSL https://getscaffold.dev/init.sh | \
   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 ```
 

--- a/init.sh
+++ b/init.sh
@@ -1051,11 +1051,59 @@ resolve_archive_url() {
 }
 
 ##
-# Download and extract the template into the current directory, then re-run.
+# Download, extract, validate, and promote the template into the current dir.
+#
+# The archive is staged in a sub-directory and only promoted once it is
+# confirmed to contain '.scaffold', so a failed download, a partial extraction,
+# or an archive that is not a Scaffold leaves the current directory clean
+# instead of tripping the empty-directory guard on the next attempt.
+#
+# @param $1 string Archive URL to download.
+# @return int 0 when the template was promoted, non-zero on any failure.
+#
+fetch_and_stage_template() {
+  local url="${1}"
+  local staging=".scaffold-bootstrap"
+
+  rm -rf "${staging}"
+  mkdir -p "${staging}"
+
+  if ! curl -fsSL "${url}" -o "${staging}/scaffold.tar.gz"; then
+    echo "Error: failed to download the template archive from ${url}." >&2
+    rm -rf "${staging}"
+    return 1
+  fi
+
+  if ! tar -xzf "${staging}/scaffold.tar.gz" -C "${staging}" --strip-components=1; then
+    echo "Error: failed to extract the template archive." >&2
+    rm -rf "${staging}"
+    return 1
+  fi
+
+  rm -f "${staging}/scaffold.tar.gz"
+
+  if [ ! -d "${staging}/.scaffold" ]; then
+    echo "Error: the downloaded archive is not a Scaffold template." >&2
+    rm -rf "${staging}"
+    return 1
+  fi
+
+  # Promote the validated staged contents (including dotfiles) into the current
+  # directory, then remove the now-empty staging directory.
+  local entry
+  for entry in "${staging}"/* "${staging}"/.[!.]*; do
+    [ -e "${entry}" ] || continue
+    mv "${entry}" .
+  done
+  rm -rf "${staging}"
+}
+
+##
+# Download the template into the current directory, then re-run in place.
 #
 # Runs only when the template is absent (for example when this script was
 # fetched and piped straight from 'curl'). Requires an empty directory so
-# nothing is clobbered. After extraction the freshly written on-disk script is
+# nothing is clobbered. After the download the freshly written on-disk script is
 # re-executed with stdin reconnected to the terminal, so interactive prompts
 # work even though this instance was fed through a pipe. Does not return.
 #
@@ -1075,45 +1123,7 @@ bootstrap_template() {
 
   echo "Downloading Scaffold from ${url}"
 
-  # Download and extract into a staging directory so a failed download, a
-  # partial extraction, or an archive that is not a Scaffold cannot leave debris
-  # in the current directory - which would otherwise trip the empty-directory
-  # guard on the next attempt and force a manual cleanup.
-  local staging=".scaffold-bootstrap"
-  rm -rf "${staging}"
-  mkdir -p "${staging}"
-
-  if ! curl -fsSL "${url}" -o "${staging}/scaffold.tar.gz"; then
-    echo "Error: failed to download the template archive from ${url}." >&2
-    rm -rf "${staging}"
-    exit 1
-  fi
-
-  if ! tar -xzf "${staging}/scaffold.tar.gz" -C "${staging}" --strip-components=1; then
-    echo "Error: failed to extract the template archive." >&2
-    rm -rf "${staging}"
-    exit 1
-  fi
-
-  rm -f "${staging}/scaffold.tar.gz"
-
-  if [ ! -d "${staging}/.scaffold" ]; then
-    echo "Error: the downloaded archive is not a Scaffold template." >&2
-    rm -rf "${staging}"
-    exit 1
-  fi
-
-  # Promote the validated staged contents (including dotfiles) into the current
-  # directory, then remove the now-empty staging directory.
-  local entry
-  for entry in "${staging}"/* "${staging}"/.[!.]*; do
-    [ -e "${entry}" ] || continue
-    mv "${entry}" .
-  done
-  rm -rf "${staging}"
-
-  if ! template_present; then
-    echo "Error: the downloaded archive is not a Scaffold template." >&2
+  if ! fetch_and_stage_template "${url}"; then
     exit 1
   fi
 

--- a/init.sh
+++ b/init.sh
@@ -24,6 +24,11 @@
 # curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
 #   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 #
+# When run without the template present (for example piped from curl in an
+# empty directory), the script downloads the Scaffold into the current
+# directory and then initializes it. The directory must be empty. Piping with
+# no options prompts interactively; pass options to run unattended.
+#
 # Run "./init.sh --help" for the full list of options.
 #
 # shellcheck disable=SC2162,SC2015
@@ -59,6 +64,10 @@ use_docs=""
 use_test_actions=""
 use_schedule=""
 remove_self=""
+
+# Ref (tag, branch, or commit) to bootstrap the template from when the script is
+# run without the template present. Empty means "use the latest release".
+archive_ref=""
 
 # Whether to run interactively. Disabled as soon as any option is passed.
 interactive=1
@@ -636,6 +645,11 @@ One-liner (non-interactive):
   curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
     bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 
+When run without the template present (e.g. piped from curl in an empty
+directory), the script downloads the Scaffold into the current directory first,
+then initialises it. The directory must be empty. Piping with no options prompts
+interactively. Set SCAFFOLD_ARCHIVE_URL to bootstrap from a specific archive URL.
+
 Identity (required in non-interactive mode):
   --namespace=VALUE              Project namespace in PascalCase (e.g. AcmeApp).
   --name=VALUE                   Project name in kebab-case (e.g. acme-app).
@@ -664,6 +678,8 @@ Features (enabled by default unless noted; use --no-<name> to disable):
   --keep                         Keep this init script (default: removed).
 
 Other:
+  --ref=VALUE                    Bootstrap from a tag, branch or commit when the
+                                 template is absent (default: latest release).
   --yes, -y                      Run non-interactively using defaults.
   --help, -h                     Show this help and exit.
 USAGE
@@ -736,6 +752,8 @@ parse_args() {
       --no-schedule) use_schedule="n" ;;
 
       --keep) remove_self="n" ;;
+
+      --ref=*) archive_ref="${1#*=}" ;;
 
       --yes | -y) interactive=0 ;;
       --help | -h)
@@ -965,6 +983,114 @@ collect_noninteractive() {
 }
 
 #-------------------------------------------------------------------------------
+# TEMPLATE BOOTSTRAP
+#-------------------------------------------------------------------------------
+
+##
+# Check whether the Scaffold template is present in the current directory.
+#
+# The '.scaffold' directory ships with the template and is removed once init
+# completes, so its presence means "the template is here, initialise in place".
+#
+template_present() {
+  [ -d ".scaffold" ]
+}
+
+##
+# Check whether the current directory is empty, including dotfiles.
+#
+dir_is_empty() {
+  [ -z "$(ls -A)" ]
+}
+
+##
+# Resolve the URL of the template archive to download.
+#
+# Precedence: an explicit SCAFFOLD_ARCHIVE_URL wins (an exact archive URL, also
+# the seam tests use to inject a local file); then --ref pins to a tag, branch,
+# or commit; otherwise the latest published release is used, falling back to the
+# default branch when the repository has no releases.
+#
+# @return string Archive URL.
+#
+resolve_archive_url() {
+  if [ -n "${SCAFFOLD_ARCHIVE_URL:-}" ]; then
+    echo "${SCAFFOLD_ARCHIVE_URL}"
+    return 0
+  fi
+
+  if [ -n "${archive_ref}" ]; then
+    echo "https://github.com/AlexSkrypnyk/scaffold/archive/${archive_ref}.tar.gz"
+    return 0
+  fi
+
+  local tag
+  tag="$(curl -fsSL "https://api.github.com/repos/AlexSkrypnyk/scaffold/releases/latest" 2>/dev/null | grep '"tag_name":' | head -n 1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' || true)"
+
+  if [ -n "${tag}" ]; then
+    echo "https://github.com/AlexSkrypnyk/scaffold/archive/refs/tags/${tag}.tar.gz"
+    return 0
+  fi
+
+  echo "https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz"
+}
+
+##
+# Download and extract the template into the current directory, then re-run.
+#
+# Runs only when the template is absent (for example when this script was
+# fetched and piped straight from 'curl'). Requires an empty directory so
+# nothing is clobbered. After extraction the freshly written on-disk script is
+# re-executed with stdin reconnected to the terminal, so interactive prompts
+# work even though this instance was fed through a pipe. Does not return.
+#
+bootstrap_template() {
+  if ! command -v tar >/dev/null 2>&1; then
+    echo "Error: 'tar' is required to bootstrap the template." >&2
+    exit 1
+  fi
+
+  if ! dir_is_empty; then
+    echo "Error: current directory is not empty. Bootstrapping requires an empty directory." >&2
+    exit 1
+  fi
+
+  local url
+  url="$(resolve_archive_url)"
+
+  echo "Downloading Scaffold from ${url}"
+
+  if ! curl -fsSL "${url}" -o scaffold.tar.gz; then
+    echo "Error: failed to download the template archive from ${url}." >&2
+    exit 1
+  fi
+
+  if ! tar -xzf scaffold.tar.gz --strip-components=1; then
+    echo "Error: failed to extract the template archive." >&2
+    rm -f scaffold.tar.gz
+    exit 1
+  fi
+
+  rm -f scaffold.tar.gz
+
+  if ! template_present; then
+    echo "Error: the downloaded archive is not a Scaffold template." >&2
+    exit 1
+  fi
+
+  # Re-run the freshly extracted script as a normal on-disk invocation so init
+  # proceeds against the downloaded files. In interactive mode reconnect stdin to
+  # the terminal (a piped stdin is already at EOF) when one is actually
+  # reachable; other modes keep the inherited stdin so non-interactive and CI
+  # runs, where /dev/tty exists but cannot be opened, are unaffected.
+  if [ "${interactive}" = "1" ] && : 2>/dev/null </dev/tty; then
+    exec bash "./init.sh" "$@" </dev/tty
+  fi
+
+  exec bash "./init.sh" "$@"
+}
+
+#-------------------------------------------------------------------------------
 # MAIN FUNCTION
 #-------------------------------------------------------------------------------
 
@@ -1047,6 +1173,12 @@ main() {
   parse_args "$@"
 
   check_dependencies || exit 1
+
+  # When the template is absent (for example this script was fetched and piped
+  # straight from 'curl'), download it into the current directory and re-run.
+  if ! template_present; then
+    bootstrap_template "$@"
+  fi
 
   if [ "${interactive}" = "1" ]; then
     collect_interactive

--- a/init.sh
+++ b/init.sh
@@ -1062,6 +1062,7 @@ bootstrap_template() {
 
   if ! curl -fsSL "${url}" -o scaffold.tar.gz; then
     echo "Error: failed to download the template archive from ${url}." >&2
+    rm -f scaffold.tar.gz
     exit 1
   fi
 

--- a/init.sh
+++ b/init.sh
@@ -1075,19 +1075,42 @@ bootstrap_template() {
 
   echo "Downloading Scaffold from ${url}"
 
-  if ! curl -fsSL "${url}" -o scaffold.tar.gz; then
+  # Download and extract into a staging directory so a failed download, a
+  # partial extraction, or an archive that is not a Scaffold cannot leave debris
+  # in the current directory - which would otherwise trip the empty-directory
+  # guard on the next attempt and force a manual cleanup.
+  local staging=".scaffold-bootstrap"
+  rm -rf "${staging}"
+  mkdir -p "${staging}"
+
+  if ! curl -fsSL "${url}" -o "${staging}/scaffold.tar.gz"; then
     echo "Error: failed to download the template archive from ${url}." >&2
-    rm -f scaffold.tar.gz
+    rm -rf "${staging}"
     exit 1
   fi
 
-  if ! tar -xzf scaffold.tar.gz --strip-components=1; then
+  if ! tar -xzf "${staging}/scaffold.tar.gz" -C "${staging}" --strip-components=1; then
     echo "Error: failed to extract the template archive." >&2
-    rm -f scaffold.tar.gz
+    rm -rf "${staging}"
     exit 1
   fi
 
-  rm -f scaffold.tar.gz
+  rm -f "${staging}/scaffold.tar.gz"
+
+  if [ ! -d "${staging}/.scaffold" ]; then
+    echo "Error: the downloaded archive is not a Scaffold template." >&2
+    rm -rf "${staging}"
+    exit 1
+  fi
+
+  # Promote the validated staged contents (including dotfiles) into the current
+  # directory, then remove the now-empty staging directory.
+  local entry
+  for entry in "${staging}"/* "${staging}"/.[!.]*; do
+    [ -e "${entry}" ] || continue
+    mv "${entry}" .
+  done
+  rm -rf "${staging}"
 
   if ! template_present; then
     echo "Error: the downloaded archive is not a Scaffold template." >&2

--- a/init.sh
+++ b/init.sh
@@ -17,6 +17,9 @@
 # Interactive prompt:
 # ./init.sh
 #
+# Interactive one-liner (downloads Scaffold, then prompts):
+# curl -fsSL https://getscaffold.dev/init.sh | bash
+#
 # Non-interactive:
 # ./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 #
@@ -644,6 +647,9 @@ With no options the script runs interactively and prompts for every choice.
 Passing any option switches to non-interactive mode: prompts are skipped,
 unspecified choices use their defaults, and --namespace, --name and --author
 are required.
+
+One-liner (interactive - downloads Scaffold, then prompts):
+  curl -fsSL https://getscaffold.dev/init.sh | bash
 
 One-liner (non-interactive):
   curl -fsSL https://getscaffold.dev/init.sh | \

--- a/init.sh
+++ b/init.sh
@@ -1241,6 +1241,11 @@ main() {
 # Run main only when the script is executed, not when it is sourced (e.g. by
 # the BATS unit tests). When piped through 'bash -s' the script has no source
 # file, so "${BASH_SOURCE[0]}" is empty - that case must still run.
+#
+# main is the final statement, which also bounds the effect of a truncated
+# 'curl ... | bash' download: every file and network operation lives inside a
+# function that only main invokes, so a cut-off download performs no real work -
+# at most the harmless top-level variable and option setup before it hits EOF.
 if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   main "$@"
 fi

--- a/init.sh
+++ b/init.sh
@@ -21,7 +21,7 @@
 # ./init.sh --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 #
 # Non-interactive one-liner (for AI agents and automation):
-# curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
+# curl -fsSL https://getscaffold.dev/init.sh | \
 #   bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 #
 # When run without the template present (for example piped from curl in an
@@ -35,6 +35,10 @@
 
 set -euo pipefail
 [ "${SCRIPT_DEBUG-}" = "1" ] && set -x
+
+# Scaffold version. Rewritten to the release tag when the script is published
+# for download from getscaffold.dev; stays "dev" in a plain checkout.
+SCAFFOLD_VERSION="dev"
 
 # Identity values. Populated from options or interactive prompts.
 namespace=""
@@ -642,7 +646,7 @@ unspecified choices use their defaults, and --namespace, --name and --author
 are required.
 
 One-liner (non-interactive):
-  curl -fsSL https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/init.sh | \
+  curl -fsSL https://getscaffold.dev/init.sh | \
     bash -s -- --namespace=AcmeApp --name=acme-app --author="Jane Doe"
 
 When run without the template present (e.g. piped from curl in an empty
@@ -682,6 +686,7 @@ Other:
                                  template is absent (default: latest release).
   --yes, -y                      Run non-interactively using defaults.
   --help, -h                     Show this help and exit.
+  --version                      Print the version ("dev" unless released).
 USAGE
 }
 
@@ -758,6 +763,10 @@ parse_args() {
       --yes | -y) interactive=0 ;;
       --help | -h)
         usage
+        exit 0
+        ;;
+      --version)
+        echo "${SCAFFOLD_VERSION}"
         exit 0
         ;;
       *)


### PR DESCRIPTION
Closes #541

## Summary

The documented one-liner previously fetched only `init.sh`, which then ran against an empty `$(pwd)` and produced nothing. `init.sh` now detects that the template is absent (no `.scaffold/` directory), downloads and extracts the Scaffold archive into the current directory, and re-executes the on-disk copy so init proceeds normally. The featured install is a bare `curl -fsSL https://getscaffold.dev/init.sh | bash` in an empty directory - it downloads Scaffold and then prompts interactively; passing options (`bash -s -- --namespace=... --name=... --author=...`) runs it unattended. A `--ref` option pins the bootstrap to a specific tag, branch, or commit, and the archive source is resolved through `SCAFFOLD_ARCHIVE_URL`, `--ref`, the latest GitHub release, then the `main` branch, in that order.

`init.sh` is now also published for download from getscaffold.dev - a copy is bundled into the documentation site's static output at build time, and the install one-liner points at `https://getscaffold.dev/init.sh`. It gains a `--version` flag that prints `dev` from a plain checkout and the release tag from the published copy (the release workflow bakes the tag into the version before deploying the docs).

## Changes

- `init.sh`: added `template_present`, `dir_is_empty`, `resolve_archive_url`, and `bootstrap_template` helpers, plus a `main()` hook that bootstraps when the template is absent.
- `init.sh`: the bootstrap download and extraction happen in a staging directory that is validated for `.scaffold` before promotion, so a failed download, a partial extraction, or a non-Scaffold archive leaves the current directory clean; it refuses a non-empty directory and reconnects stdin to `/dev/tty` on re-exec so interactive prompts work despite the pipe.
- `init.sh`: added the `--ref=VALUE` option to pin the bootstrap source and a `--version` flag backed by a `SCAFFOLD_VERSION` constant (`dev` by default); pointed the install one-liner at `https://getscaffold.dev/init.sh` in the header and help, featuring the interactive `curl ... | bash` form.
- `.scaffold/docs`: bundle `init.sh` into the site's `static/` output at build time (`copy-init` prebuild/prestart hooks) so it is downloadable at `https://getscaffold.dev/init.sh`; the generated copy is git-ignored.
- `.github/workflows/scaffold-release-docs.yml`: bake the release tag into `init.sh`'s `SCAFFOLD_VERSION` before building the docs (escaping `sed` metacharacters), so the published script reports its release version.
- `.scaffold/tests/phpunit/src/InitTest.php`: added end-to-end curl tests (bootstrap into an empty dir, refusal on a non-empty dir, interactive prompting with no options, and cleanup after an invalid archive), all network-free via a `file://` tarball injected through `SCAFFOLD_ARCHIVE_URL`.
- `.scaffold/tests/bats/init.bats`: added unit tests for `parse_args --ref`, `--version`, `template_present`, `dir_is_empty`, and `resolve_archive_url`.
- `README.md`, `.scaffold/CLAUDE.md`, and `.scaffold/docs/content/README.mdx`: documented the empty-directory bootstrap, the interactive and unattended one-liners, `--ref` (passed via `bash -s --`), and the `SCAFFOLD_ARCHIVE_URL` test seam; the getscaffold.dev Introduction now leads with the curl install and keeps the checkout path as a labelled alternative.

## Before / After

```
BEFORE: curl | bash into an empty directory produced nothing
────────────────────────────────────────────────────────────
$ mkdir empty-dir && cd empty-dir
$ curl -fsSL .../init.sh | bash

  ┌──────────┐
  │ init.sh  │ ──▶ looks for .scaffold/ in $(pwd)
  └──────────┘           │
                          ▼
                    not found, no fallback
                          │
                          ▼
                  script exits, directory still empty

$ ls
(nothing)


AFTER: curl | bash bootstraps the template first
────────────────────────────────────────────────────────────
$ mkdir empty-dir && cd empty-dir
$ curl -fsSL https://getscaffold.dev/init.sh | bash

  ┌──────────┐
  │ init.sh  │ ──▶ .scaffold/ absent ──▶ bootstrap_template()
  └──────────┘                                │
                                              ▼
                        resolve archive URL:
                        SCAFFOLD_ARCHIVE_URL ▶ --ref ▶
                        latest release ▶ main branch
                                              │
                                              ▼
                        download + extract into staging,
                        validate .scaffold, promote to cwd
                                              │
                                              ▼
                        exec ./init.sh "$@" </dev/tty
                                              │
                                              ▼
                        init prompts (or uses options), then
                        renders and cleans up

$ ls
composer.json  src/  tests/  README.md  ...

Distribution: init.sh is bundled into the docs site static output, so
              https://getscaffold.dev/init.sh serves the script, and
              `init.sh --version` prints the baked release tag (or `dev`).
```
