### PR TITLE
[#560] [#561] Added Docker canary publishing, an overridable image name, and expanded docs.

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -34,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
-          images: yournamespace/yourproject
+          images: ${{ vars.DOCKER_IMAGE || 'yournamespace/yourproject' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -60,3 +60,42 @@ jobs:
         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}
         uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3
         timeout-minutes: 30
+
+  push-canary-to-registry:
+    name: Docker canary
+    needs: test-docker
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ vars.DOCKER_IMAGE || 'yournamespace/yourproject' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          push: true
+          tags: ${{ vars.DOCKER_IMAGE || 'yournamespace/yourproject' }}:canary
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.scaffold/docs/content/docker/README.mdx
+++ b/.scaffold/docs/content/docker/README.mdx
@@ -5,77 +5,9 @@ sidebar_position: 6
 
 # Docker
 
-This scaffold provides optional Docker support for building and publishing
-container images. When enabled during initialization, it includes a Dockerfile,
-an entrypoint script, and GitHub Actions workflows for testing and releasing
-Docker images.
+This scaffold provides optional Docker support for building, testing, and
+publishing container images. When enabled during initialization, it includes a
+`Dockerfile`, an entrypoint script, and GitHub Actions workflows.
 
-## Dockerfile
-
-The included `Dockerfile` uses a minimal Alpine Linux base image with Bash
-installed. It follows OCI image labeling conventions and uses a dedicated
-entrypoint script.
-
-```dockerfile
-FROM alpine:3
-
-RUN apk add --no-cache bash
-
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-```
-
-## Entrypoint
-
-The `entrypoint.sh` script enforces strict shell options (`set -euo pipefail`)
-and forwards arguments to the container command.
-
-## Building and running
-
-```bash
-# Build the image
-docker build -t yournamespace/yourproject .
-
-# Run the container
-docker run --rm yournamespace/yourproject
-```
-
-## Linting
-
-The Dockerfile is linted using [Hadolint](https://github.com/hadolint/hadolint),
-a Dockerfile linter that helps enforce best practices.
-
-```bash
-# Lint locally
-hadolint Dockerfile
-```
-
-Linting also runs automatically in CI via the `test-docker.yml` workflow.
-
-## CI/CD workflows
-
-### Testing (`test-docker.yml`)
-
-Runs on pushes to `main` and pull requests. This workflow:
-
-1. Lints the Dockerfile with Hadolint
-2. Builds the Docker image using Docker Buildx
-3. Runs the container to verify it starts correctly
-
-### Release (`release-docker.yml`)
-
-Runs on tag pushes. This workflow:
-
-1. Sets up QEMU and Docker Buildx for multi-architecture builds
-2. Authenticates with Docker Hub
-3. Builds and pushes multi-arch images (`linux/amd64`, `linux/arm64`)
-
-#### Docker Hub credentials
-
-The release workflow requires the following repository secrets:
-
-- `DOCKER_USER` — Docker Hub username
-- `DOCKER_PASS` — Docker Hub access token
-
-Set these in your repository's **Settings > Secrets and variables > Actions**.
+It also provides tooling for linting the Dockerfile and for publishing images to
+a registry, including a rolling `canary` image on every merge to `main`.

--- a/.scaffold/docs/content/docker/image.mdx
+++ b/.scaffold/docs/content/docker/image.mdx
@@ -1,0 +1,41 @@
+---
+title: Image
+sidebar_position: 2
+---
+
+# Image
+
+The Docker support centers on a small, self-contained image built from a minimal
+base image and a dedicated entrypoint script.
+
+## Dockerfile
+
+The included [`Dockerfile`](https://github.com/AlexSkrypnyk/scaffold/blob/main/Dockerfile)
+uses a minimal Alpine Linux base image with Bash installed. It follows OCI image
+labeling conventions and uses a dedicated entrypoint script.
+
+```dockerfile
+FROM alpine:3
+
+RUN apk add --no-cache bash
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+```
+
+## Entrypoint
+
+The [`entrypoint.sh`](https://github.com/AlexSkrypnyk/scaffold/blob/main/entrypoint.sh)
+script enforces strict shell options (`set -euo pipefail`) and forwards
+arguments to the container command.
+
+## Building and running
+
+```bash
+# Build the image
+docker build -t yournamespace/yourproject .
+
+# Run the container
+docker run --rm yournamespace/yourproject
+```

--- a/.scaffold/docs/content/docker/linting.mdx
+++ b/.scaffold/docs/content/docker/linting.mdx
@@ -1,0 +1,21 @@
+---
+title: Linting
+sidebar_position: 3
+---
+
+# Linting
+
+The Dockerfile is linted using [Hadolint](https://github.com/hadolint/hadolint),
+a Dockerfile linter that helps enforce best practices and catch common mistakes
+before an image is built.
+
+## Usage
+
+Lint the Dockerfile locally:
+
+```bash
+hadolint Dockerfile
+```
+
+Linting also runs automatically in CI as part of the [testing](testing)
+workflow, so pull requests are checked before they are merged.

--- a/.scaffold/docs/content/docker/publishing.mdx
+++ b/.scaffold/docs/content/docker/publishing.mdx
@@ -1,0 +1,43 @@
+---
+title: Publishing
+sidebar_position: 5
+---
+
+# Publishing
+
+The scaffold publishes multi-architecture (`linux/amd64`, `linux/arm64`) images
+to a container registry in two ways: a rolling `canary` image on every merge to
+`main`, and an immutable image on every tagged release.
+
+## Canary images
+
+On a merge to `main`, the [testing](testing) workflow builds and pushes an image
+tagged `canary` once the tests pass. This provides a bleeding-edge build in
+between tagged releases. The canary push runs only on `main`, so pull requests
+and forks never publish an image.
+
+## Tagged releases
+
+The [`release-docker.yml`](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/release-docker.yml)
+workflow runs on tag pushes. It:
+
+1. Sets up QEMU and Docker Buildx for multi-architecture builds
+2. Authenticates with Docker Hub
+3. Builds and pushes multi-arch images tagged from the release metadata
+
+## Registry credentials
+
+Both publishing paths require the following repository secrets:
+
+- `DOCKER_USER` - Docker Hub username
+- `DOCKER_PASS` - Docker Hub access token
+
+Set these in your repository's **Settings > Secrets and variables > Actions**.
+
+## Overriding the image name
+
+By default the image is published under the `yournamespace/yourproject` name
+chosen during initialization. To publish elsewhere without editing the workflows
+(for example, to push to a throwaway repository while testing the pipeline end to
+end), set a `DOCKER_IMAGE` repository or organization **variable** to the target
+image name. When it is unset, the default name is used.

--- a/.scaffold/docs/content/docker/publishing.mdx
+++ b/.scaffold/docs/content/docker/publishing.mdx
@@ -36,8 +36,8 @@ Set these in your repository's **Settings > Secrets and variables > Actions**.
 
 ## Overriding the image name
 
-By default the image is published under the `yournamespace/yourproject` name
-chosen during initialization. To publish elsewhere without editing the workflows
-(for example, to push to a throwaway repository while testing the pipeline end to
-end), set a `DOCKER_IMAGE` repository or organization **variable** to the target
-image name. When it is unset, the default name is used.
+By default the image is published under the name chosen during initialization.
+To publish elsewhere without editing the workflows (for example, to push to a
+throwaway repository while testing the pipeline end to end), set a `DOCKER_IMAGE`
+repository or organization **variable** to the target image name. When it is
+unset, the default name is used.

--- a/.scaffold/docs/content/docker/testing.mdx
+++ b/.scaffold/docs/content/docker/testing.mdx
@@ -1,0 +1,20 @@
+---
+title: Testing
+sidebar_position: 4
+---
+
+# Testing
+
+The [`test-docker.yml`](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/test-docker.yml)
+workflow validates the image on every push to `main` and on every pull request.
+It:
+
+1. Lints the Dockerfile with Hadolint
+2. Builds the image using Docker Buildx
+3. Runs the container to verify it starts correctly
+
+Because the image is built and run on every pull request, a change that breaks
+the build or the entrypoint is caught before it is merged.
+
+On a merge to `main`, once these checks pass, the same workflow also publishes a
+`canary` image. See [Publishing](publishing) for details.

--- a/.scaffold/tests/phpunit/fixtures/init/docker/.github/workflows/release-docker.yml
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/.github/workflows/release-docker.yml
@@ -34,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@__HASH__ # __VERSION__
         with:
-          images: yodashut/force-crystal
+          images: ${{ vars.DOCKER_IMAGE || 'yodashut/force-crystal' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@__HASH__ # __VERSION__

--- a/.scaffold/tests/phpunit/fixtures/init/docker/.github/workflows/test-docker.yml
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/.github/workflows/test-docker.yml
@@ -58,3 +58,42 @@ jobs:
         if: ${{ !cancelled() && github.event.inputs.enable_terminal }}
         uses: mxschmitt/action-tmate@__HASH__ # __VERSION__
         timeout-minutes: 30
+
+  push-canary-to-registry:
+    name: Docker canary
+    needs: test-docker
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@__HASH__ # __VERSION__
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@__HASH__ # __VERSION__
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@__HASH__ # __VERSION__
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@__HASH__ # __VERSION__
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@__HASH__ # __VERSION__
+        with:
+          images: ${{ vars.DOCKER_IMAGE || 'yodashut/force-crystal' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@__HASH__ # __VERSION__
+        with:
+          context: .
+          push: true
+          tags: ${{ vars.DOCKER_IMAGE || 'yodashut/force-crystal' }}:canary
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.scaffold/tests/phpunit/fixtures/init/docker/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/AGENTS.md
@@ -1,4 +1,4 @@
-@@ -11,213 +11,33 @@
+@@ -11,213 +11,35 @@
  testing, code quality tools, and CI/CD workflows.
  
  
@@ -77,11 +77,14 @@
 +### CI/CD
  
 -## NodeJS Application Architecture
-+- `.github/workflows/test-docker.yml` - Build and lint Docker image
++- `.github/workflows/test-docker.yml` - Build and lint the Docker image, and push a `canary`-tagged image on merge to `main`
 +- `.github/workflows/release-docker.yml` - Build and push multi-arch image to Docker Hub on tag
  
 -### Standalone Single-File Script
--
++Docker Hub credentials are stored as repository secrets:
++- `DOCKER_USER` - Docker Hub username
++- `DOCKER_PASS` - Docker Hub access token
+ 
 -Single-file CLI script structure:
 -
 -- **Location:** `nodejs-script` file (or custom name)
@@ -221,9 +224,7 @@
 -
 -- `.github/workflows/test-nodejs.yml` - NodeJS testing
 -- `.github/workflows/release-nodejs.yml` - Script release to GitHub Releases
-+Docker Hub credentials are stored as repository secrets:
-+- `DOCKER_USER` - Docker Hub username
-+- `DOCKER_PASS` - Docker Hub access token
++Override the published image name (release and canary) by setting the `DOCKER_IMAGE` repository or organization variable; it defaults to `yodashut/force-crystal`.
  
  
  ## Documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,12 +307,14 @@ docker run --rm -i hadolint/hadolint < Dockerfile
 
 ### CI/CD
 
-- `.github/workflows/test-docker.yml` - Build and lint Docker image
+- `.github/workflows/test-docker.yml` - Build and lint the Docker image, and push a `canary`-tagged image on merge to `main`
 - `.github/workflows/release-docker.yml` - Build and push multi-arch image to Docker Hub on tag
 
 Docker Hub credentials are stored as repository secrets:
 - `DOCKER_USER` - Docker Hub username
 - `DOCKER_PASS` - Docker Hub access token
+
+Override the published image name (release and canary) by setting the `DOCKER_IMAGE` repository or organization variable; it defaults to `yournamespace/yourproject`.
 
 [//]: # (#;> DOCKER)
 


### PR DESCRIPTION
Closes #561
Closes #560

## Summary

This improves the scaffold's Docker support in three related ways: the published image name is now overridable at CI time, a `canary` image is published on every merge to `main`, and the Docker documentation is expanded to match the depth of the PHP and NodeJS sections. Together these make the Docker publish pipeline testable end to end (push to a throwaway registry by setting one variable) and give users a bleeding-edge image in between tagged releases.

## Changes

### Overridable image name

`release-docker.yml` previously pushed to the hardcoded `yournamespace/yourproject` image that `init.sh` substitutes at scaffold time. The `docker/metadata-action` `images` input is now `${{ vars.DOCKER_IMAGE || 'yournamespace/yourproject' }}`, so a `DOCKER_IMAGE` repository or organization variable redirects the push target without editing the workflow. When the variable is unset the default (init-substituted) behaviour is unchanged, following the repo's existing `vars.*` fallback convention.

### Canary image on merge to `main` (#561)

A new `push-canary-to-registry` job in `test-docker.yml` builds and pushes a multi-architecture (`linux/amd64`, `linux/arm64`) image tagged `canary` on every merge to `main`. It is gated behind the test job (`needs: test-docker`) and `if: github.event_name == 'push'`, so it only runs after the tests pass and never on pull requests or forks. It reuses the same overridable image name. This mirrors the canary pattern in `drevops/mariadb-drupal-data`.

### Docker documentation (#560)

The single `docker/README.mdx` page is split into an overview plus focused sub-pages, matching the multi-page structure of the PHP, NodeJS and Shell sections on the documentation site: `image` (Dockerfile, entrypoint, building and running), `linting` (Hadolint), `testing` (the `test-docker.yml` workflow), and `publishing` (the canary and tagged-release flows, credentials, and the `DOCKER_IMAGE` override). `AGENTS.md` is also updated to mention the canary push and the `DOCKER_IMAGE` variable.

## Before / After

```
BEFORE
──────
  merge to main ─> test-docker.yml ─> lint + build + run          (no publish)
  tag           ─> release-docker.yml ─> push  yournamespace/yourproject:<ver>

  The published image name is always the hardcoded, init-substituted value.


AFTER
─────
  merge to main ─> test-docker.yml ─> lint + build + run
                                       └─(tests pass, push event)─> push  IMAGE:canary
  tag           ─> release-docker.yml ────────────────────────────> push  IMAGE:<ver>

  where IMAGE = ${{ vars.DOCKER_IMAGE || 'yournamespace/yourproject' }}

    vars.DOCKER_IMAGE set   ─> that value                  (CI-configurable target)
    vars.DOCKER_IMAGE unset ─> yournamespace/yourproject   (unchanged default)
```
