### PR TITLE
[#572] Added CONTRIBUTING files and fixed documentation drift.

### DIFF
--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance for **maintaining and developing the scaffold
 template itself**, not for projects created from it.
 
-> **⚠️ MAINTENANCE MODE**: This file contains guidance for **maintaining the Scafoold template itself**.
+> **⚠️ MAINTENANCE MODE**: This file contains guidance for **maintaining the Scaffold template itself**.
 >
 > For working with **custom projects created from this template**, see the main project guide: `../CLAUDE.md`
 

--- a/.scaffold/docs/content/documentation.mdx
+++ b/.scaffold/docs/content/documentation.mdx
@@ -47,7 +47,7 @@ npm run spellcheck
 ## Publishing to Netlify on pull requests
 
 Documentation is published to Netlify on every pull request and merge to `main`
-using the [Deploy Docs to GitHub Pages](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/docs.yml)
+using the [Test Docs](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/test-docs.yml)
 GitHub Action.
 
 Deployed documentation link will be added to the pull request as a comment.
@@ -63,7 +63,7 @@ to the `Secrets and variables > Actions > Repository secrets` in GitHub settings
 ## Publishing to GitHub pages on release
 
 Documentation is published to GitHub Pages on release (tag) using
-the [Deploy Docs to GitHub Pages](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/docs.yml)
+the [Release docs](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/release-docs.yml)
 GitHub Action.
 
 This GitHub Action is designed to automatically build and publish documentation

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -538,6 +538,20 @@ SETTINGS
   assert_file_not_exists "${tmpdir}/.claude/settings.json"
 }
 
+@test "process_contributing promotes the distributable CONTRIBUTING file" {
+  local tmpdir="${BATS_TEST_TMPDIR}/process_contributing"
+  mkdir -p "${tmpdir}"
+  echo "Contributing guide" >"${tmpdir}/CONTRIBUTING.dist.md"
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_contributing
+  popd >/dev/null || return 1
+
+  assert_file_exists "${tmpdir}/CONTRIBUTING.md"
+  assert_file_not_exists "${tmpdir}/CONTRIBUTING.dist.md"
+  assert_file_contains "${tmpdir}/CONTRIBUTING.md" "Contributing guide"
+}
+
 @test "parse_args --ref sets the bootstrap ref" {
   parse_args --ref=1.2.3
   assert_equal "${archive_ref}" "1.2.3"

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -552,6 +552,32 @@ SETTINGS
   assert_file_contains "${tmpdir}/CONTRIBUTING.md" "Contributing guide"
 }
 
+@test "process_project runs the full flow and promotes the dist docs" {
+  local tmpdir="${BATS_TEST_TMPDIR}/process_project"
+  mkdir -p "${tmpdir}"
+  printf '# /.editorconfig   export-ignore\n# /docs            export-ignore\n' >"${tmpdir}/.gitattributes"
+  echo "README dist content" >"${tmpdir}/README.dist.md"
+  echo "Contributing dist content" >"${tmpdir}/CONTRIBUTING.dist.md"
+
+  namespace="AcmeApp"
+  project="acme-app"
+  author="Jane Doe"
+  project_pascalcase="AcmeApp"
+  remove_self="n"
+
+  # Stub the placeholder-logo download so the flow never hits the network.
+  curl() { return 0; }
+
+  pushd "${tmpdir}" >/dev/null || return 1
+  process_project
+  popd >/dev/null || return 1
+
+  assert_file_exists "${tmpdir}/README.md"
+  assert_file_not_exists "${tmpdir}/README.dist.md"
+  assert_file_exists "${tmpdir}/CONTRIBUTING.md"
+  assert_file_not_exists "${tmpdir}/CONTRIBUTING.dist.md"
+}
+
 @test "parse_args --ref sets the bootstrap ref" {
   parse_args --ref=1.2.3
   assert_equal "${archive_ref}" "1.2.3"

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thank you for considering a contribution to this project. This guide explains
+how to set up a local environment and run the linting and tests.
+
+## Installation
+
+
+    composer install
+
+
+
+    npm install
+
+
+
+    npm ci --prefix tests/bats
+
+
+## Linting
+
+
+    composer lint
+
+
+
+    npm run lint
+
+
+
+    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+
+
+## Testing
+
+
+    composer test
+
+
+
+    npm run test
+
+
+
+    ./tests/bats/node_modules/.bin/bats tests/bats
+

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/CONTRIBUTING.md
@@ -1,47 +1,23 @@
 # Contributing
 
-Thank you for considering a contribution to this project. This guide explains
-how to set up a local environment and run the linting and tests.
-
-## Installation
+Thank you for considering a contribution to this project. This guide covers
+setting up a local environment and running the linting and tests.
 
 
     composer install
-
-
-
-    npm install
-
-
-
-    npm ci --prefix tests/bats
-
-
-## Linting
-
-
     composer lint
-
-
-
-    npm run lint
-
-
-
-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
-
-
-## Testing
-
-
     composer test
 
 
 
+    npm install
+    npm run lint
     npm run test
 
 
 
+    npm ci --prefix tests/bats
+    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
     ./tests/bats/node_modules/.bin/bats tests/bats
 

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/README.md
@@ -62,30 +62,13 @@ Download the latest release from GitHub releases page.
 |-------------|---------------|------------------------------------|
 | `arg1`      |               | Description of the first argument. |
 | `--option1` | `default1`    | Option with a default value.       |
-| `--option2` | None          | Option wihtout a value.            |
+| `--option2` | None          | Option without a value.            |
 
 
-## Maintenance
+## Contributing
 
-
-    composer install
-    composer lint
-    composer test
-
-
-
-    npm install
-    npm run lint
-    npm run test
-
-
-
-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
-
-    npm ci --prefix tests/bats
-    ./tests/bats/node_modules/.bin/bats tests/bats
-
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup and the
+linting and testing commands.
 
 ## Updating
 

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/content/README.mdx
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/content/README.mdx
@@ -41,7 +41,7 @@ npm run spellcheck
 ## Publishing to Netlify on pull requests
 
 Documentation is published to Netlify on every pull request and merge to `main`
-using the [Deploy Docs to GitHub Pages](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/docs.yml)
+using the [Test Docs](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/test-docs.yml)
 GitHub Action.
 
 Deployed documentation link will be added to the pull request as a comment.
@@ -57,7 +57,7 @@ to the `Secrets and variables > Actions > Repository secrets` in GitHub settings
 ## Publishing to GitHub pages on release
 
 Documentation is published to GitHub Pages on release (tag) using
-the [Deploy Docs to GitHub Pages](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/docs.yml)
+the [Release docs](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/release-docs.yml)
 GitHub Action.
 
 This GitHub Action is designed to automatically build and publish documentation

--- a/.scaffold/tests/phpunit/fixtures/init/docker/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/CONTRIBUTING.md
@@ -1,43 +1,21 @@
-@@ -6,42 +6,14 @@
- ## Installation
+@@ -4,20 +4,4 @@
+ setting up a local environment and running the linting and tests.
  
  
 -    composer install
- 
- 
--
--    npm install
--
--
--
--    npm ci --prefix tests/bats
--
--
- ## Linting
- 
- 
 -    composer lint
- 
- 
--
--    npm run lint
--
--
--
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--
- ## Testing
- 
- 
 -    composer test
 -
 -
 -
+-    npm install
+-    npm run lint
 -    npm run test
 -
 -
 -
+-    npm ci --prefix tests/bats
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
 -    ./tests/bats/node_modules/.bin/bats tests/bats
  

--- a/.scaffold/tests/phpunit/fixtures/init/docker/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+@@ -6,42 +6,14 @@
+ ## Installation
+ 
+ 
+-    composer install
+ 
+ 
+-
+-    npm install
+-
+-
+-
+-    npm ci --prefix tests/bats
+-
+-
+ ## Linting
+ 
+ 
+-    composer lint
+ 
+ 
+-
+-    npm run lint
+-
+-
+-
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-
+-
+ ## Testing
+ 
+ 
+-    composer test
+-
+-
+-
+-    npm run test
+-
+-
+-
+-    ./tests/bats/node_modules/.bin/bats tests/bats
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/docker/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/README.md
@@ -8,7 +8,7 @@
  [![codecov](https://codecov.io/gh/yodashut/force-crystal/graph/badge.svg)](https://codecov.io/gh/yodashut/force-crystal)
  ![GitHub release (latest by date)](https://img.shields.io/github/v/release/yodashut/force-crystal)
  ![LICENSE](https://img.shields.io/github/license/yodashut/force-crystal)
-@@ -30,61 +27,17 @@
+@@ -30,39 +27,12 @@
  ## Installation
  
  
@@ -28,8 +28,8 @@
  
 -    vendor/bin/force-crystal
  
- 
- 
+-
+-
 -    ./nodejs-script value/of/argument
 -
 -
@@ -44,29 +44,7 @@
 -|-------------|---------------|------------------------------------|
 -| `arg1`      |               | Description of the first argument. |
 -| `--option1` | `default1`    | Option with a default value.       |
--| `--option2` | None          | Option wihtout a value.            |
--
--
- ## Maintenance
+-| `--option2` | None          | Option without a value.            |
  
  
--    composer install
--    composer lint
--    composer test
--
--
--
--    npm install
--    npm run lint
--    npm run test
--
--
--
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--    npm ci --prefix tests/bats
--    ./tests/bats/node_modules/.bin/bats tests/bats
- 
- 
- ## Updating
+ ## Contributing

--- a/.scaffold/tests/phpunit/fixtures/init/name/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+@@ -28,8 +28,8 @@
+ 
+ 
+ 
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
++    shellcheck star-forge.sh tests/bats/*.bash tests/bats/*.bats
++    shfmt -i 2 -ci -s -d star-forge.sh tests/bats/*.bash tests/bats/*.bats
+ 
+ 
+ ## Testing

--- a/.scaffold/tests/phpunit/fixtures/init/name/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/CONTRIBUTING.md
@@ -1,11 +1,10 @@
-@@ -28,8 +28,8 @@
+@@ -17,7 +17,7 @@
  
  
- 
+     npm ci --prefix tests/bats
 -    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
 -    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
 +    shellcheck star-forge.sh tests/bats/*.bash tests/bats/*.bats
 +    shfmt -i 2 -ci -s -d star-forge.sh tests/bats/*.bash tests/bats/*.bats
+     ./tests/bats/node_modules/.bin/bats tests/bats
  
- 
- ## Testing

--- a/.scaffold/tests/phpunit/fixtures/init/name/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/README.md
@@ -56,14 +56,3 @@
  
  
  
-@@ -80,8 +80,8 @@
- 
- 
- 
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
-+    shellcheck star-forge.sh tests/bats/*.bash tests/bats/*.bats
-+    shfmt -i 2 -ci -s -d star-forge.sh tests/bats/*.bash tests/bats/*.bats
- 
-     npm ci --prefix tests/bats
-     ./tests/bats/node_modules/.bin/bats tests/bats

--- a/.scaffold/tests/phpunit/fixtures/init/name/docs/content/README.mdx
+++ b/.scaffold/tests/phpunit/fixtures/init/name/docs/content/README.mdx
@@ -20,8 +20,8 @@
  ## Publishing to Netlify on pull requests
  
  Documentation is published to Netlify on every pull request and merge to `main`
--using the [Deploy Docs to GitHub Pages](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/docs.yml)
-+using the [Deploy Docs to GitHub Pages](https://github.com/jeditemple/star-forge/blob/main/.github/workflows/docs.yml)
+-using the [Test Docs](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/test-docs.yml)
++using the [Test Docs](https://github.com/jeditemple/star-forge/blob/main/.github/workflows/test-docs.yml)
  GitHub Action.
  
  Deployed documentation link will be added to the pull request as a comment.
@@ -29,8 +29,8 @@
  ## Publishing to GitHub pages on release
  
  Documentation is published to GitHub Pages on release (tag) using
--the [Deploy Docs to GitHub Pages](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/docs.yml)
-+the [Deploy Docs to GitHub Pages](https://github.com/jeditemple/star-forge/blob/main/.github/workflows/docs.yml)
+-the [Release docs](https://github.com/yodashut/force-crystal/blob/main/.github/workflows/release-docs.yml)
++the [Release docs](https://github.com/jeditemple/star-forge/blob/main/.github/workflows/release-docs.yml)
  GitHub Action.
  
  This GitHub Action is designed to automatically build and publish documentation

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/CONTRIBUTING.md
@@ -1,43 +1,21 @@
-@@ -6,42 +6,14 @@
- ## Installation
+@@ -4,20 +4,4 @@
+ setting up a local environment and running the linting and tests.
  
  
 -    composer install
- 
- 
--
--    npm install
--
--
--
--    npm ci --prefix tests/bats
--
--
- ## Linting
- 
- 
 -    composer lint
- 
- 
--
--    npm run lint
--
--
--
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--
- ## Testing
- 
- 
 -    composer test
 -
 -
 -
+-    npm install
+-    npm run lint
 -    npm run test
 -
 -
 -
+-    npm ci --prefix tests/bats
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
 -    ./tests/bats/node_modules/.bin/bats tests/bats
  

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+@@ -6,42 +6,14 @@
+ ## Installation
+ 
+ 
+-    composer install
+ 
+ 
+-
+-    npm install
+-
+-
+-
+-    npm ci --prefix tests/bats
+-
+-
+ ## Linting
+ 
+ 
+-    composer lint
+ 
+ 
+-
+-    npm run lint
+-
+-
+-
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-
+-
+ ## Testing
+ 
+ 
+-    composer test
+-
+-
+-
+-    npm run test
+-
+-
+-
+-    ./tests/bats/node_modules/.bin/bats tests/bats
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/README.md
@@ -8,7 +8,7 @@
  [![codecov](https://codecov.io/gh/yodashut/force-crystal/graph/badge.svg)](https://codecov.io/gh/yodashut/force-crystal)
  ![GitHub release (latest by date)](https://img.shields.io/github/v/release/yodashut/force-crystal)
  ![LICENSE](https://img.shields.io/github/license/yodashut/force-crystal)
-@@ -30,61 +27,17 @@
+@@ -30,39 +27,12 @@
  ## Installation
  
  
@@ -28,8 +28,8 @@
  
 -    vendor/bin/force-crystal
  
- 
- 
+-
+-
 -    ./nodejs-script value/of/argument
 -
 -
@@ -44,29 +44,7 @@
 -|-------------|---------------|------------------------------------|
 -| `arg1`      |               | Description of the first argument. |
 -| `--option1` | `default1`    | Option with a default value.       |
--| `--option2` | None          | Option wihtout a value.            |
--
--
- ## Maintenance
+-| `--option2` | None          | Option without a value.            |
  
  
--    composer install
--    composer lint
--    composer test
--
--
--
--    npm install
--    npm run lint
--    npm run test
--
--
--
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--    npm ci --prefix tests/bats
--    ./tests/bats/node_modules/.bin/bats tests/bats
- 
- 
- ## Updating
+ ## Contributing

--- a/.scaffold/tests/phpunit/fixtures/init/nodejs/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/nodejs/CONTRIBUTING.md
@@ -1,32 +1,12 @@
-@@ -6,10 +6,7 @@
- ## Installation
+@@ -4,11 +4,6 @@
+ setting up a local environment and running the linting and tests.
  
  
 -    composer install
- 
--
--
-     npm install
- 
- 
-@@ -20,10 +17,7 @@
- ## Linting
- 
- 
 -    composer lint
- 
--
--
-     npm run lint
- 
- 
-@@ -33,9 +27,6 @@
- 
- 
- ## Testing
--
--
 -    composer test
+-
+-
  
- 
- 
+     npm install
+     npm run lint

--- a/.scaffold/tests/phpunit/fixtures/init/nodejs/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/nodejs/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+@@ -6,10 +6,7 @@
+ ## Installation
+ 
+ 
+-    composer install
+ 
+-
+-
+     npm install
+ 
+ 
+@@ -20,10 +17,7 @@
+ ## Linting
+ 
+ 
+-    composer lint
+ 
+-
+-
+     npm run lint
+ 
+ 
+@@ -33,9 +27,6 @@
+ 
+ 
+ ## Testing
+-
+-
+-    composer test
+ 
+ 
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/nodejs/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/nodejs/README.md
@@ -28,25 +28,19 @@
      ./nodejs-script value/of/argument
  
  
-@@ -56,21 +49,7 @@
+@@ -54,15 +47,6 @@
  
+     ./force-crystal.sh
  
- 
+-
+-
 -### CLI options
 -
 -| Name        | Default value | Description                        |
 -|-------------|---------------|------------------------------------|
 -| `arg1`      |               | Description of the first argument. |
 -| `--option1` | `default1`    | Option with a default value.       |
--| `--option2` | None          | Option wihtout a value.            |
--
--
- ## Maintenance
--
--
--    composer install
--    composer lint
--    composer test
+-| `--option2` | None          | Option without a value.            |
  
  
- 
+ ## Contributing

--- a/.scaffold/tests/phpunit/fixtures/init/php_command/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_command/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+@@ -14,9 +14,6 @@
+ 
+ 
+ 
+-    npm ci --prefix tests/bats
+-
+-
+ ## Linting
+ 
+ 
+@@ -28,10 +25,6 @@
+ 
+ 
+ 
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-
+-
+ ## Testing
+ 
+ 
+@@ -41,7 +34,4 @@
+ 
+     npm run test
+ 
+-
+-
+-    ./tests/bats/node_modules/.bin/bats tests/bats
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/php_command/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_command/CONTRIBUTING.md
@@ -1,29 +1,10 @@
-@@ -14,9 +14,6 @@
- 
- 
- 
--    npm ci --prefix tests/bats
--
--
- ## Linting
- 
- 
-@@ -28,10 +25,6 @@
- 
- 
- 
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--
- ## Testing
- 
- 
-@@ -41,7 +34,4 @@
- 
+@@ -15,9 +15,3 @@
      npm run test
  
--
--
--    ./tests/bats/node_modules/.bin/bats tests/bats
  
+-
+-    npm ci --prefix tests/bats
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    ./tests/bats/node_modules/.bin/bats tests/bats
+-

--- a/.scaffold/tests/phpunit/fixtures/init/php_command/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_command/README.md
@@ -16,28 +16,13 @@
  ## Usage
  
  
-@@ -52,10 +48,7 @@
+@@ -50,9 +46,6 @@
  
+     ./nodejs-script value/of/argument
  
- 
+-
+-
 -    ./force-crystal.sh
  
--
--
- ### CLI options
- 
- | Name        | Default value | Description                        |
-@@ -78,13 +71,6 @@
-     npm run lint
-     npm run test
- 
--
--
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--    npm ci --prefix tests/bats
--    ./tests/bats/node_modules/.bin/bats tests/bats
  
  
- ## Updating

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+@@ -14,9 +14,6 @@
+ 
+ 
+ 
+-    npm ci --prefix tests/bats
+-
+-
+ ## Linting
+ 
+ 
+@@ -28,10 +25,6 @@
+ 
+ 
+ 
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-
+-
+ ## Testing
+ 
+ 
+@@ -41,7 +34,4 @@
+ 
+     npm run test
+ 
+-
+-
+-    ./tests/bats/node_modules/.bin/bats tests/bats
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/CONTRIBUTING.md
@@ -1,29 +1,10 @@
-@@ -14,9 +14,6 @@
- 
- 
- 
--    npm ci --prefix tests/bats
--
--
- ## Linting
- 
- 
-@@ -28,10 +25,6 @@
- 
- 
- 
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--
- ## Testing
- 
- 
-@@ -41,7 +34,4 @@
- 
+@@ -15,9 +15,3 @@
      npm run test
  
--
--
--    ./tests/bats/node_modules/.bin/bats tests/bats
  
+-
+-    npm ci --prefix tests/bats
+-    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
+-    ./tests/bats/node_modules/.bin/bats tests/bats
+-

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/README.md
@@ -16,28 +16,13 @@
  ## Usage
  
  
-@@ -52,10 +48,7 @@
+@@ -50,9 +46,6 @@
  
+     ./nodejs-script value/of/argument
  
- 
+-
+-
 -    ./force-crystal.sh
  
--
--
- ### CLI options
- 
- | Name        | Default value | Description                        |
-@@ -78,13 +71,6 @@
-     npm run lint
-     npm run test
- 
--
--
--    shellcheck force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--    shfmt -i 2 -ci -s -d force-crystal.sh tests/bats/*.bash tests/bats/*.bats
--
--    npm ci --prefix tests/bats
--    ./tests/bats/node_modules/.bin/bats tests/bats
  
  
- ## Updating

--- a/.scaffold/tests/phpunit/fixtures/init/shell/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/shell/CONTRIBUTING.md
@@ -1,32 +1,12 @@
-@@ -6,10 +6,7 @@
- ## Installation
+@@ -4,11 +4,6 @@
+ setting up a local environment and running the linting and tests.
  
  
 -    composer install
- 
--
--
-     npm install
- 
- 
-@@ -20,10 +17,7 @@
- ## Linting
- 
- 
 -    composer lint
- 
--
--
-     npm run lint
- 
- 
-@@ -33,9 +27,6 @@
- 
- 
- ## Testing
--
--
 -    composer test
+-
+-
  
- 
- 
+     npm install
+     npm run lint

--- a/.scaffold/tests/phpunit/fixtures/init/shell/CONTRIBUTING.md
+++ b/.scaffold/tests/phpunit/fixtures/init/shell/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+@@ -6,10 +6,7 @@
+ ## Installation
+ 
+ 
+-    composer install
+ 
+-
+-
+     npm install
+ 
+ 
+@@ -20,10 +17,7 @@
+ ## Linting
+ 
+ 
+-    composer lint
+ 
+-
+-
+     npm run lint
+ 
+ 
+@@ -33,9 +27,6 @@
+ 
+ 
+ ## Testing
+-
+-
+-    composer test
+ 
+ 
+ 

--- a/.scaffold/tests/phpunit/fixtures/init/shell/README.md
+++ b/.scaffold/tests/phpunit/fixtures/init/shell/README.md
@@ -28,25 +28,19 @@
      ./nodejs-script value/of/argument
  
  
-@@ -56,21 +49,7 @@
+@@ -54,15 +47,6 @@
  
+     ./force-crystal.sh
  
- 
+-
+-
 -### CLI options
 -
 -| Name        | Default value | Description                        |
 -|-------------|---------------|------------------------------------|
 -| `arg1`      |               | Description of the first argument. |
 -| `--option1` | `default1`    | Option with a default value.       |
--| `--option2` | None          | Option wihtout a value.            |
--
--
- ## Maintenance
--
--
--    composer install
--    composer lint
--    composer test
+-| `--option2` | None          | Option without a value.            |
  
  
- 
+ ## Contributing

--- a/CONTRIBUTING.dist.md
+++ b/CONTRIBUTING.dist.md
@@ -1,65 +1,29 @@
 # Contributing
 
-Thank you for considering a contribution to this project. This guide explains
-how to set up a local environment and run the linting and tests.
-
-## Installation
+Thank you for considering a contribution to this project. This guide covers
+setting up a local environment and running the linting and tests.
 
 [//]: # (#;< PHP)
 
     composer install
-
-[//]: # (#;> PHP)
-
-[//]: # (#;< NODEJS)
-
-    npm install
-
-[//]: # (#;> NODEJS)
-
-[//]: # (#;< SHELL)
-
-    npm ci --prefix tests/bats
-
-[//]: # (#;> SHELL)
-
-## Linting
-
-[//]: # (#;< PHP)
-
     composer lint
-
-[//]: # (#;> PHP)
-
-[//]: # (#;< NODEJS)
-
-    npm run lint
-
-[//]: # (#;> NODEJS)
-
-[//]: # (#;< SHELL)
-
-    shellcheck shell-command.sh tests/bats/*.bash tests/bats/*.bats
-    shfmt -i 2 -ci -s -d shell-command.sh tests/bats/*.bash tests/bats/*.bats
-
-[//]: # (#;> SHELL)
-
-## Testing
-
-[//]: # (#;< PHP)
-
     composer test
 
 [//]: # (#;> PHP)
 
 [//]: # (#;< NODEJS)
 
+    npm install
+    npm run lint
     npm run test
 
 [//]: # (#;> NODEJS)
 
 [//]: # (#;< SHELL)
 
+    npm ci --prefix tests/bats
+    shellcheck shell-command.sh tests/bats/*.bash tests/bats/*.bats
+    shfmt -i 2 -ci -s -d shell-command.sh tests/bats/*.bash tests/bats/*.bats
     ./tests/bats/node_modules/.bin/bats tests/bats
 
 [//]: # (#;> SHELL)

--- a/CONTRIBUTING.dist.md
+++ b/CONTRIBUTING.dist.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thank you for considering a contribution to this project. This guide explains
+how to set up a local environment and run the linting and tests.
+
+## Installation
+
+[//]: # (#;< PHP)
+
+    composer install
+
+[//]: # (#;> PHP)
+
+[//]: # (#;< NODEJS)
+
+    npm install
+
+[//]: # (#;> NODEJS)
+
+[//]: # (#;< SHELL)
+
+    npm ci --prefix tests/bats
+
+[//]: # (#;> SHELL)
+
+## Linting
+
+[//]: # (#;< PHP)
+
+    composer lint
+
+[//]: # (#;> PHP)
+
+[//]: # (#;< NODEJS)
+
+    npm run lint
+
+[//]: # (#;> NODEJS)
+
+[//]: # (#;< SHELL)
+
+    shellcheck shell-command.sh tests/bats/*.bash tests/bats/*.bats
+    shfmt -i 2 -ci -s -d shell-command.sh tests/bats/*.bash tests/bats/*.bats
+
+[//]: # (#;> SHELL)
+
+## Testing
+
+[//]: # (#;< PHP)
+
+    composer test
+
+[//]: # (#;> PHP)
+
+[//]: # (#;< NODEJS)
+
+    npm run test
+
+[//]: # (#;> NODEJS)
+
+[//]: # (#;< SHELL)
+
+    ./tests/bats/node_modules/.bin/bats tests/bats
+
+[//]: # (#;> SHELL)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Contributions to Scaffold are welcome.
+
+Scaffold is a multi-stack project template. The `.scaffold/` directory holds the
+template's own infrastructure and is removed from generated projects by
+[`init.sh`](init.sh). The maintenance guide in
+[`.scaffold/CLAUDE.md`](.scaffold/CLAUDE.md) documents the template
+architecture, the `init.sh` token system, and the test and fixture workflow -
+read it before changing template files.
+
+## Local development
+
+The example application is tested from the repository root:
+
+```bash
+composer install
+composer lint
+composer test
+```
+
+The `init.sh` script and the template files have a separate suite that must be
+run for any change to them:
+
+```bash
+cd .scaffold/tests/phpunit
+composer install
+composer lint
+composer test
+```
+
+After changing `init.sh` or any template file, regenerate the fixtures and
+review the diff before committing:
+
+```bash
+cd .scaffold/tests/phpunit
+composer update-snapshots
+```

--- a/README.dist.md
+++ b/README.dist.md
@@ -81,37 +81,14 @@ Download the latest release from GitHub releases page.
 |-------------|---------------|------------------------------------|
 | `arg1`      |               | Description of the first argument. |
 | `--option1` | `default1`    | Option with a default value.       |
-| `--option2` | None          | Option wihtout a value.            |
+| `--option2` | None          | Option without a value.            |
 
 [//]: # (#;> PHP)
 
-## Maintenance
+## Contributing
 
-[//]: # (#;< PHP)
-
-    composer install
-    composer lint
-    composer test
-
-[//]: # (#;> PHP)
-
-[//]: # (#;< NODEJS)
-
-    npm install
-    npm run lint
-    npm run test
-
-[//]: # (#;> NODEJS)
-
-[//]: # (#;< SHELL)
-
-    shellcheck shell-command.sh tests/bats/*.bash tests/bats/*.bats
-    shfmt -i 2 -ci -s -d shell-command.sh tests/bats/*.bash tests/bats/*.bats
-
-    npm ci --prefix tests/bats
-    ./tests/bats/node_modules/.bin/bats tests/bats
-
-[//]: # (#;> SHELL)
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for local development setup and the
+linting and testing commands.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
     and [publish](.github/workflows/release-php.yml) PHP as [PHAR](box.json)
 - **NodeJS**
   - [`package.json`](package.json)
-  - CI config to [build and test](.github/workflows/test-nodehs.yml) and test
+  - CI config to [build and test](.github/workflows/test-nodejs.yml) and test
     for NodeJS
 - **Docker**
   - [`Dockerfile`](Dockerfile) with minimal Alpine-based image and [`entrypoint.sh`](entrypoint.sh)
@@ -52,11 +52,11 @@
   - CI config to [publish](.github/workflows/release-docker.yml) multi-arch
     images (`linux/amd64`, `linux/arm64`) to Docker Hub
 - **CI**
-  - [Release drafter](.github/workflows/release-drafter.yml)
+  - [Release drafter](.github/workflows/draft-release-notes.yml)
   - Release asset packaging and upload
   - [PR auto-assign](.github/workflows/assign-author.yml)
 - **Documentation**
-  - [Readme with badges](README.dist.md) and [generated logo](logo.png)
+  - [Readme with badges](README.dist.md) and [contributing guide](CONTRIBUTING.dist.md), plus a [generated logo](logo.png)
   - [Scaffold](docs) for the documentation site using [Docusaurus](https://docusaurus.io/)
   - Spell check with [CSpell](https://cspell.org/)
   - [Terminal recorder](.scaffold/assets/update-assets.php) rendering an animated SVG plus an [`AsciinemaPlayer`](docs/src/components/AsciinemaPlayer) docs component

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@
     and [publish](.github/workflows/release-php.yml) PHP as [PHAR](box.json)
 - **NodeJS**
   - [`package.json`](package.json)
-  - CI config to [build and test](.github/workflows/test-nodejs.yml) and test
-    for NodeJS
+  - CI config to [build and test](.github/workflows/test-nodejs.yml) for NodeJS
 - **Docker**
   - [`Dockerfile`](Dockerfile) with minimal Alpine-based image and [`entrypoint.sh`](entrypoint.sh)
   - CI config to [lint and test](.github/workflows/test-docker.yml) Docker

--- a/docs/content/README.mdx
+++ b/docs/content/README.mdx
@@ -47,7 +47,7 @@ npm run spellcheck
 ## Publishing to Netlify on pull requests
 
 Documentation is published to Netlify on every pull request and merge to `main`
-using the [Deploy Docs to GitHub Pages](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/docs.yml)
+using the [Test Docs](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/test-docs.yml)
 GitHub Action.
 
 Deployed documentation link will be added to the pull request as a comment.
@@ -63,7 +63,7 @@ to the `Secrets and variables > Actions > Repository secrets` in GitHub settings
 ## Publishing to GitHub pages on release
 
 Documentation is published to GitHub Pages on release (tag) using
-the [Deploy Docs to GitHub Pages](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/docs.yml)
+the [Release docs](https://github.com/AlexSkrypnyk/scaffold/blob/main/.github/workflows/release-docs.yml)
 GitHub Action.
 
 This GitHub Action is designed to automatically build and publish documentation

--- a/init.sh
+++ b/init.sh
@@ -547,6 +547,16 @@ process_readme() {
 }
 
 ##
+# Promote the distributable CONTRIBUTING guide to its final name.
+#
+# Scaffold keeps its own CONTRIBUTING.md; CONTRIBUTING.dist.md is the guide that
+# ships to generated projects, mirroring the README.dist.md handling.
+#
+process_contributing() {
+  mv CONTRIBUTING.dist.md "CONTRIBUTING.md" >/dev/null 2>&1 || true
+}
+
+##
 # Replace the self-update skill references with placeholder tokens.
 #
 # The initialised project must keep instructions that point at the upstream
@@ -1207,6 +1217,8 @@ process_project() {
   cleanup_renovate_managers
 
   process_readme "${project}"
+
+  process_contributing
 
   process_internal "${namespace}" "${project}" "${author}" "${project_pascalcase}"
 


### PR DESCRIPTION
Closes #572

## Summary

Adds a dedicated contributing-guide system to Scaffold: `CONTRIBUTING.dist.md` ships to generated projects with token-gated local-development commands per language, and `CONTRIBUTING.md` documents contributing to Scaffold itself. `init.sh` gains a `process_contributing()` step that promotes `CONTRIBUTING.dist.md` to `CONTRIBUTING.md` in generated projects, mirroring the existing `README.dist.md` handling, and the init snapshot fixtures are regenerated to match. A handful of unrelated broken documentation links and typos are fixed along the way.

## Changes

- Added `CONTRIBUTING.dist.md`, the distributable guide whose install/lint/test commands are grouped per language and gated by `PHP`/`NODEJS`/`SHELL` tokens, so only the relevant commands ship per project type and feature-less variants (Docker-only, no-language) render just the intro with no empty sections.
- Added `CONTRIBUTING.md`, Scaffold's own contributor guide describing the `.scaffold/` layout, pointing at `.scaffold/CLAUDE.md` for the maintenance guide, and documenting the two independent test suites (root example app vs. `.scaffold/tests/phpunit`) plus the `composer update-snapshots` fixture-regeneration step.
- Routed the local-development `## Maintenance` section out of `README.dist.md` into a short `## Contributing` pointer to the new `CONTRIBUTING.md`.
- Taught `init.sh` a `process_contributing()` function, called from `process_project()` right after `process_readme()`, that promotes `CONTRIBUTING.dist.md` to `CONTRIBUTING.md` in generated projects.
- Added BATS unit tests in `.scaffold/tests/bats/init.bats` for `process_contributing` and for the full `process_project` orchestration, so the new step and the previously-untested `process_readme`/`process_contributing`/`process_internal` call flow are covered by the kcov run.
- Regenerated the init snapshot fixtures under `.scaffold/tests/phpunit/fixtures/init/` for all variants (`_baseline`, `docker`, `name`, `no_languages`, `nodejs`, `php_command`, `php_script`, `shell`) to add `CONTRIBUTING.md` and trim the old `Maintenance` block from `README.md`.
- Fixed broken workflow links in `README.md` (`test-nodehs.yml` to `test-nodejs.yml`, `release-drafter.yml` to `draft-release-notes.yml`), removed the redundant "and test" wording from the NodeJS bullet, and listed `CONTRIBUTING.dist.md` alongside `README.dist.md` in the documentation bullet.
- Fixed broken `docs.yml` links in `docs/content/README.mdx` and `.scaffold/docs/content/documentation.mdx`, pointing them at the real `test-docs.yml` and `release-docs.yml` workflows.
- Fixed typos: `Scafoold` to `Scaffold` in `.scaffold/CLAUDE.md`, and `wihtout` to `without` in `README.dist.md`.

## Before / After

```
BEFORE                                   AFTER
┌───────────────────────────────┐        ┌───────────────────────────────┐
│ README.dist.md                │        │ README.dist.md                │
│                               │        │                               │
│ ## Maintenance                │        │ ## Contributing               │
│   composer install/lint/test  │  ==>   │   See CONTRIBUTING.md for     │
│   npm install/lint/test       │        │   local development setup     │
│   (token-gated per language)  │        │   and the linting and tests.  │
└───────────────────────────────┘        └───────────────────────────────┘
                                          ┌───────────────────────────────┐
                                          │ CONTRIBUTING.dist.md    (new) │
                                          │   intro                       │
                                          │   composer install/lint/test  │
                                          │   npm install/lint/test       │
                                          │   (grouped per language,      │
                                          │    token-gated; intro only    │
                                          │    when no language selected) │
                                          └───────────────────────────────┘

┌───────────────────────────────┐        ┌───────────────────────────────┐
│ init.sh: process_project()    │        │ init.sh: process_project()    │
│   process_readme()            │  ==>   │   process_readme()            │
│   ...                         │        │   process_contributing() (new)│
└───────────────────────────────┘        │   ...                         │
                                         └───────────────────────────────┘

┌───────────────────────────────┐        ┌───────────────────────────────┐
│ Generated project root        │        │ Generated project root        │
│   README.md                   │  ==>   │   README.md (points to guide) │
│   (install/lint/test inline)  │        │   CONTRIBUTING.md       (new) │
│                               │        │   (install/lint/test cmds)    │
└───────────────────────────────┘        └───────────────────────────────┘
```
