### PR TITLE
Updated BATS tests to use 'bats-helpers' v2.

### DIFF
--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -130,7 +130,7 @@ Same pattern used in `phpcs.xml` (`<file>php-script.php</file>`).
 3. **BATS Tests** - Test shell scripts
   - Location: `tests/bats/`
   - Purpose: Validate `shell-command.sh` functionality
-  - Includes: TUI testing helpers, mocking system via `run_steps()`
+  - Includes: TUI testing helpers, mocking system via `steps_run()`
 
 ### Rules for Template Changes
 
@@ -198,8 +198,8 @@ composer test-coverage
 The scaffold includes advanced BATS testing utilities:
 
 - **TUI Testing** - `tui_run()` function simulates interactive input
-- **Command Mocking** - `run_steps()` system mocks external commands
-- **Fixture Exports** - `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1`
+- **Command Mocking** - `steps_run()` system mocks external commands
+- **Fixture Exports** - `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1`
 
 Example from `tests/bats/shell-command.bats`:
 
@@ -208,13 +208,13 @@ Example from `tests/bats/shell-command.bats`:
   declare -a STEPS=(
     '@curl -sL https://api.example.com # [{"data":"mocked"}]'
   )
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   tui_run topic_name
   assert_success
   assert_output_contains "mocked"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }
 ```
 

--- a/.scaffold/tests/bats/_helper.bash
+++ b/.scaffold/tests/bats/_helper.bash
@@ -11,7 +11,7 @@ setup() {
   # Setup libraries.
   export BATS_LIB_PATH="${BATS_TEST_DIRNAME}/node_modules"
   bats_load_library bats-helpers
-  setup_mock
+  mock_setup
 
   # Print debug information if "--verbose-run" is passed.
   # LCOV_EXCL_START

--- a/.scaffold/tests/bats/package-lock.json
+++ b/.scaffold/tests/bats/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "GPL-2.0-or-later",
             "devDependencies": {
-                "bats-helpers": "npm:@drevops/bats-helpers@^1.5"
+                "bats-helpers": "npm:@drevops/bats-helpers@^2.0"
             }
         },
         "node_modules/bats": {
@@ -24,13 +24,13 @@
         },
         "node_modules/bats-helpers": {
             "name": "@drevops/bats-helpers",
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@drevops/bats-helpers/-/bats-helpers-1.5.2.tgz",
-            "integrity": "sha512-Ze4J+G+wsSYwD4gkSpyo5AxKnbKXYQKw131LgNjobAyeQbDLUxTsoYezn0q+7c2JJsltdcFTrgj9W4rlo4KXVg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@drevops/bats-helpers/-/bats-helpers-2.0.0.tgz",
+            "integrity": "sha512-2oxr9SXOnogwBd+pB7sRP0LviP9Y7ReeRRlEa0cI9PHprhbd9Vm9Rv1NTdL2i8IxvktuQFtvCi25PkzihNxa7w==",
             "dev": true,
-            "license": "GPL-2.0-or-later",
+            "license": "GPL-3.0-or-later",
             "dependencies": {
-                "bats": "^1"
+                "bats": "^1.13"
             }
         }
     }

--- a/.scaffold/tests/bats/package.json
+++ b/.scaffold/tests/bats/package.json
@@ -4,6 +4,6 @@
     "description": "Packages used for testing of scaffold",
     "license": "GPL-2.0-or-later",
     "devDependencies": {
-        "bats-helpers": "npm:@drevops/bats-helpers@^1.5"
+        "bats-helpers": "npm:@drevops/bats-helpers@^2.0"
     }
 }

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/_helper.bash
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/_helper.bash
@@ -22,7 +22,7 @@ setup() {
   bats_load_library bats-helpers
 
   # Setup command mocking.
-  setup_mock
+  mock_setup
 
   # Current directory where the test is run from.
   # shellcheck disable=SC2155
@@ -37,7 +37,7 @@ setup() {
 
   # Copy codebase at the last commit into the BUILD_DIR.
   # Tests requiring to work with the copy of the codebase should opt-in using
-  # BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
+  # BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
   # Note that during development of tests the local changes need to be
   # committed.
   fixture_export_codebase "${BUILD_DIR}" "${ROOT_DIR}"

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/package.json
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/package.json
@@ -4,6 +4,6 @@
     "description": "Packages used for testing",
     "license": "GPL-3.0-or-later",
     "devDependencies": {
-        "bats-helpers": "npm:@drevops/bats-helpers@^1.2"
+        "bats-helpers": "npm:@drevops/bats-helpers@^2.0"
     }
 }

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/shell-command.bats
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/shell-command.bats
@@ -9,7 +9,7 @@
 
 load _helper
 
-export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+export BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
 
 # Script file for TUI testing.
 export SCRIPT_FILE="force-crystal.sh"
@@ -42,7 +42,7 @@ export SCRIPT_FILE="force-crystal.sh"
     '@curl -sL https://official-joke-api.appspot.com/jokes/mocked_topic/random # [{"type":"mocked_topic","setup":"mocked_setup","punchline":"mocked_punchline","id":251}]'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export SHOULD_PROCEED=y
   tui_run mocked_topic
@@ -50,5 +50,5 @@ export SCRIPT_FILE="force-crystal.sh"
   assert_output_contains "mocked_setup"
   assert_output_contains "mocked_punchline"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }

--- a/.scaffold/tests/phpunit/fixtures/init/name/tests/bats/shell-command.bats
+++ b/.scaffold/tests/phpunit/fixtures/init/name/tests/bats/shell-command.bats
@@ -11,7 +11,7 @@
  # shellcheck disable=SC2030,SC2031,SC2034
  
 @@ -12,7 +12,7 @@
- export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+ export BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
  
  # Script file for TUI testing.
 -export SCRIPT_FILE="force-crystal.sh"

--- a/tests/bats/_helper.bash
+++ b/tests/bats/_helper.bash
@@ -22,7 +22,7 @@ setup() {
   bats_load_library bats-helpers
 
   # Setup command mocking.
-  setup_mock
+  mock_setup
 
   # Current directory where the test is run from.
   # shellcheck disable=SC2155
@@ -37,7 +37,7 @@ setup() {
 
   # Copy codebase at the last commit into the BUILD_DIR.
   # Tests requiring to work with the copy of the codebase should opt-in using
-  # BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
+  # BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
   # Note that during development of tests the local changes need to be
   # committed.
   fixture_export_codebase "${BUILD_DIR}" "${ROOT_DIR}"

--- a/tests/bats/package-lock.json
+++ b/tests/bats/package-lock.json
@@ -9,43 +9,45 @@
             "version": "1.0.0",
             "license": "GPL-3.0-or-later",
             "devDependencies": {
-                "bats-helpers": "npm:@drevops/bats-helpers@^1.2"
+                "bats-helpers": "npm:@drevops/bats-helpers@^2.0"
             }
         },
         "node_modules/bats": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/bats/-/bats-1.10.0.tgz",
-            "integrity": "sha512-yOQrC7npuCrN+Ic3TyjTjJlzHa0qlK3oEO6VAYPWwFeutx/GmpljIyB6uNSl/UTASyc2w4FgVuA/QMMf9OdsCw==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
+            "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "bats": "bin/bats"
             }
         },
         "node_modules/bats-helpers": {
             "name": "@drevops/bats-helpers",
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@drevops/bats-helpers/-/bats-helpers-1.3.0.tgz",
-            "integrity": "sha512-2dQyexmp7fyVTzVKfN9PXKDqGxcdD8u5qGY1mObeNq4wJ98dGoCocA+2ORGUD1bseNyh0fSWrDPiSLvoN1YBCA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@drevops/bats-helpers/-/bats-helpers-2.0.0.tgz",
+            "integrity": "sha512-2oxr9SXOnogwBd+pB7sRP0LviP9Y7ReeRRlEa0cI9PHprhbd9Vm9Rv1NTdL2i8IxvktuQFtvCi25PkzihNxa7w==",
             "dev": true,
+            "license": "GPL-3.0-or-later",
             "dependencies": {
-                "bats": "^1"
+                "bats": "^1.13"
             }
         }
     },
     "dependencies": {
         "bats": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/bats/-/bats-1.10.0.tgz",
-            "integrity": "sha512-yOQrC7npuCrN+Ic3TyjTjJlzHa0qlK3oEO6VAYPWwFeutx/GmpljIyB6uNSl/UTASyc2w4FgVuA/QMMf9OdsCw==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
+            "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
             "dev": true
         },
         "bats-helpers": {
-            "version": "npm:@drevops/bats-helpers@1.3.0",
-            "resolved": "https://registry.npmjs.org/@drevops/bats-helpers/-/bats-helpers-1.3.0.tgz",
-            "integrity": "sha512-2dQyexmp7fyVTzVKfN9PXKDqGxcdD8u5qGY1mObeNq4wJ98dGoCocA+2ORGUD1bseNyh0fSWrDPiSLvoN1YBCA==",
+            "version": "npm:@drevops/bats-helpers@2.0.0",
+            "resolved": "https://registry.npmjs.org/@drevops/bats-helpers/-/bats-helpers-2.0.0.tgz",
+            "integrity": "sha512-2oxr9SXOnogwBd+pB7sRP0LviP9Y7ReeRRlEa0cI9PHprhbd9Vm9Rv1NTdL2i8IxvktuQFtvCi25PkzihNxa7w==",
             "dev": true,
             "requires": {
-                "bats": "^1"
+                "bats": "^1.13"
             }
         }
     }

--- a/tests/bats/package.json
+++ b/tests/bats/package.json
@@ -4,6 +4,6 @@
     "description": "Packages used for testing",
     "license": "GPL-3.0-or-later",
     "devDependencies": {
-        "bats-helpers": "npm:@drevops/bats-helpers@^1.2"
+        "bats-helpers": "npm:@drevops/bats-helpers@^2.0"
     }
 }

--- a/tests/bats/shell-command.bats
+++ b/tests/bats/shell-command.bats
@@ -9,7 +9,7 @@
 
 load _helper
 
-export BATS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
+export BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
 
 # Script file for TUI testing.
 export SCRIPT_FILE="shell-command.sh"
@@ -42,7 +42,7 @@ export SCRIPT_FILE="shell-command.sh"
     '@curl -sL https://official-joke-api.appspot.com/jokes/mocked_topic/random # [{"type":"mocked_topic","setup":"mocked_setup","punchline":"mocked_punchline","id":251}]'
   )
 
-  mocks="$(run_steps "setup")"
+  mocks="$(steps_run "setup")"
 
   export SHOULD_PROCEED=y
   tui_run mocked_topic
@@ -50,5 +50,5 @@ export SCRIPT_FILE="shell-command.sh"
   assert_output_contains "mocked_setup"
   assert_output_contains "mocked_punchline"
 
-  run_steps "assert" "${mocks[@]}"
+  steps_run "assert" "${mocks[@]}"
 }


### PR DESCRIPTION
## Summary

Both BATS test suites in this repository (`tests/bats/` for the example application and `.scaffold/tests/bats/` for the scaffold's own test harness) move from `@drevops/bats-helpers` v1 to v2. The upgrade renames two deprecated helper calls and one environment variable per the package's migration guide, and pulls in `bats` 1.13 (up from 1.10), which v2 requires. Maintenance documentation and the init command's test fixtures are regenerated so they stay consistent with the new API surface.

## Changes

- Bumped `@drevops/bats-helpers` from `^1.2` to `^2.0` in `tests/bats/package.json`, and from `^1.5` to `^2.0` in `.scaffold/tests/bats/package.json`, then regenerated both `package-lock.json` files, which also moves the resolved `bats` version from `1.10.0` to `1.13.0`.
- Renamed `setup_mock` to `mock_setup` in both `_helper.bash` files.
- Renamed `run_steps` to `steps_run` in `tests/bats/shell-command.bats`.
- Renamed the `BATS_FIXTURE_EXPORT_CODEBASE_ENABLED` environment variable to `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED` in both `_helper.bash` files and in `tests/bats/shell-command.bats`.
- Updated `.scaffold/CLAUDE.md` maintenance docs to reference `steps_run()` and the renamed fixture-export variable.
- Regenerated the init command's test fixtures under `.scaffold/tests/phpunit/fixtures/init/` (the baseline scaffolded project and the `name` scenario patch) via `composer update-snapshots` so they mirror the same renames.

Two behavioural changes in v2 have no rename or deprecation notice, so they don't show up in this diff, but are worth flagging for review: mocks are strict by default now, so a call with no matching expectation fails instead of falling back to a default response, and `steps_run "assert"` now calls `mock_verify` internally, so a declared expectation that never fires is treated as an error. Neither change affects the existing tests in this repository.

## Before / After

```
┌─ Dependency versions ───────────────────────────────────────────────
│
│   Suite                          v1 (before)    v2 (after)
│   tests/bats/                           ^1.2          ^2.0
│   .scaffold/tests/bats/                 ^1.5          ^2.0
│   bats (via bats-helpers)             1.10.0        1.13.0
│
└───────────────────────────────────────────────────────────────────────

┌─ Helper API surface ─────────────────────────────────────────────────
│
│   setup_mock                      ──►  mock_setup
│   run_steps "setup"               ──►  steps_run "setup"
│   run_steps "assert"              ──►  steps_run "assert"
│                                         (now also calls mock_verify)
│
│   BATS_FIXTURE_EXPORT_CODEBASE_ENABLED
│     ──►  BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED
│
└───────────────────────────────────────────────────────────────────────
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Upgrade both BATS test suites to `@drevops/bats-helpers` v2.
- Update the required BATS version from 1.10.0 to 1.13.0.
- Rename deprecated helpers:
  - `setup_mock` to `mock_setup`
  - `run_steps` to `steps_run`
- Rename the fixture export variable to `BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED`.
- Regenerate dependency lockfiles and init command test fixtures.
- Update BATS maintenance documentation.

The v2 strict mock behavior and automatic mock verification do not affect the existing tests.

## Possibly related

- Possibly related to `#588`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->