### PR TITLE
[#571] Excluded 'logo.png' from distribution archives.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 # /.github         export-ignore
 # /.gitignore      export-ignore
 # /docs            export-ignore
+# /logo.png        export-ignore
 #;< PHP
 # /tests           export-ignore
 # /phpcs.xml       export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/.gitattributes
@@ -5,6 +5,7 @@
 /.github         export-ignore
 /.gitignore      export-ignore
 /docs            export-ignore
+/logo.png        export-ignore
 /tests           export-ignore
 /phpcs.xml       export-ignore
 /phpstan.neon    export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/docker/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/docker/.gitattributes
@@ -1,7 +1,7 @@
-@@ -5,10 +5,4 @@
- /.github         export-ignore
+@@ -6,10 +6,4 @@
  /.gitignore      export-ignore
  /docs            export-ignore
+ /logo.png        export-ignore
 -/tests           export-ignore
 -/phpcs.xml       export-ignore
 -/phpstan.neon    export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/no_docs_no_ai_arch_docs/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/no_docs_no_ai_arch_docs/.gitattributes
@@ -3,6 +3,6 @@
  /.github         export-ignore
  /.gitignore      export-ignore
 -/docs            export-ignore
+ /logo.png        export-ignore
  /tests           export-ignore
  /phpcs.xml       export-ignore
- /phpstan.neon    export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/no_languages/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/no_languages/.gitattributes
@@ -1,7 +1,7 @@
-@@ -5,10 +5,4 @@
- /.github         export-ignore
+@@ -6,10 +6,4 @@
  /.gitignore      export-ignore
  /docs            export-ignore
+ /logo.png        export-ignore
 -/tests           export-ignore
 -/phpcs.xml       export-ignore
 -/phpstan.neon    export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/no_renovate/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/no_renovate/.gitattributes
@@ -1,4 +1,4 @@
-@@ -11,4 +11,3 @@
+@@ -12,4 +12,3 @@
  /phpunit.xml     export-ignore
  /rector.php      export-ignore
  /.npmignore      export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/nodejs/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/nodejs/.gitattributes
@@ -1,7 +1,7 @@
-@@ -5,10 +5,5 @@
- /.github         export-ignore
+@@ -6,10 +6,5 @@
  /.gitignore      export-ignore
  /docs            export-ignore
+ /logo.png        export-ignore
 -/tests           export-ignore
 -/phpcs.xml       export-ignore
 -/phpstan.neon    export-ignore

--- a/.scaffold/tests/phpunit/fixtures/init/shell/.gitattributes
+++ b/.scaffold/tests/phpunit/fixtures/init/shell/.gitattributes
@@ -1,7 +1,7 @@
-@@ -5,10 +5,5 @@
- /.github         export-ignore
+@@ -6,10 +6,5 @@
  /.gitignore      export-ignore
  /docs            export-ignore
+ /logo.png        export-ignore
 -/tests           export-ignore
 -/phpcs.xml       export-ignore
 -/phpstan.neon    export-ignore

--- a/init.sh
+++ b/init.sh
@@ -711,6 +711,7 @@ process_internal() {
   uncomment_line ".gitattributes" "\/.github"
   uncomment_line ".gitattributes" "\/.gitignore"
   uncomment_line ".gitattributes" "\/docs"
+  uncomment_line ".gitattributes" "\/logo.png"
   uncomment_line ".gitattributes" "\/tests"
   uncomment_line ".gitattributes" "\/phpcs.xml"
   uncomment_line ".gitattributes" "\/phpstan.neon"


### PR DESCRIPTION
Closes #571

## Summary

`init.sh` downloads a placeholder image to `logo.png` in the root of every generated project, but `.gitattributes` never marked it `export-ignore`, so it shipped inside `git archive` output, GitHub release source archives, and Composer dist packages of generated projects. This adds the missing `export-ignore` entry so `logo.png` is excluded from distribution archives, matching how `/docs` and the other root-level scaffold-only files are already handled.

## Changes

- `.gitattributes`: added `# /logo.png        export-ignore` after the `/docs` entry, above the `#;< PHP` token block.
- `init.sh`: added a matching `uncomment_line ".gitattributes" "\/logo.png"` call in `process_internal()`, alongside the existing uncomment calls for `/.github`, `/.gitignore`, and `/docs`.
- `.scaffold/tests/phpunit/fixtures/init/_baseline/.gitattributes` and the six scenario fixtures (`docker`, `no_docs_no_ai_arch_docs`, `no_languages`, `no_renovate`, `nodejs`, `shell`): regenerated to include the new `/logo.png` line, with unified-diff patch fixtures shifting their hunk headers by one line accordingly.

## Before / After

```
Before                                    After
------                                    -----
.gitattributes                            .gitattributes
  # /.github         export-ignore          # /.github         export-ignore
  # /.gitignore      export-ignore          # /.gitignore      export-ignore
  # /docs            export-ignore          # /docs            export-ignore
  #;< PHP                                   # /logo.png        export-ignore
  ...                                       #;< PHP
                                             ...

Generated project's git archive:          Generated project's git archive:
  project/                                  project/
  ├── README.md                             ├── README.md
  ├── logo.png   <- shipped                 ├── src/
  ├── src/                                  └── ...
  └── ...                                   (logo.png excluded)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add `/logo.png export-ignore` to `.gitattributes`.
- Update `init.sh` to enable the rule in scaffolded projects.
- Regenerate baseline and scenario fixtures.
- Adjust fixture `.gitattributes` files and unified-diff hunk headers.

This prevents `logo.png` from shipping in Git archives, GitHub source archives, and Composer packages.

Resolves `#571`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->