### PR TITLE
Converged naming, structure and comment register across the codebase.

### DIFF
--- a/.scaffold/assets/svg-term-render.js
+++ b/.scaffold/assets/svg-term-render.js
@@ -21,7 +21,6 @@ const {render} = require('svg-term');
 // sync with fg colours.
 const svgTermDefaultTheme = require('svg-term/lib/default-theme');
 
-// Parse command line arguments.
 const args = process.argv.slice(2);
 
 if (args.length < 2 || args.includes('--help')) {
@@ -37,7 +36,6 @@ if (args.length < 2 || args.includes('--help')) {
 const inputFile = args[0];
 const outputFile = args[1];
 
-// Parse options.
 let at = null;
 let lineHeight = 1.0;
 let fontFamily = 'Consolas, "Courier New", Courier, "Liberation Mono", monospace';
@@ -55,7 +53,6 @@ for (let i = 2; i < args.length; i++) {
   }
 }
 
-// Read input cast file and convert v3 to v2 if needed.
 // svg-term only supports asciicast v1 and v2 formats, but asciinema 3.x
 // produces v3 format with two breaking differences:
 //   1. Header uses {term: {cols, rows, type}} instead of {width, height}
@@ -67,7 +64,6 @@ if (lines.length > 0) {
   try {
     const header = JSON.parse(lines[0]);
     if (header.version === 3) {
-      // Convert header.
       header.version = 2;
       if (header.term) {
         header.width = header.term.cols;
@@ -80,7 +76,6 @@ if (lines.length > 0) {
         }
         delete header.term;
       }
-      // Convert event lines: relative timestamps to absolute, drop non-"o" events.
       const convertedLines = [JSON.stringify(header)];
       let absoluteTime = 0;
       for (let i = 1; i < lines.length; i++) {
@@ -144,7 +139,6 @@ if (at !== null) {
   options.at = at;
 }
 
-// Render SVG.
 try {
   const svg = render(input, options);
   fs.writeFileSync(outputFile, svg, 'utf8');

--- a/.scaffold/assets/update-assets.php
+++ b/.scaffold/assets/update-assets.php
@@ -281,9 +281,9 @@ function main(): void {
   }
   finally {
     removeDir($workspace_dir);
-    cleanupFile($expect_script);
-    cleanupFile($cast_file);
-    cleanupFile($svg_input);
+    removeFile($expect_script);
+    removeFile($cast_file);
+    removeFile($svg_input);
   }
 
   verbose('Done.');
@@ -297,7 +297,7 @@ function checkDependencies(): void {
   $missing = [];
 
   foreach ($deps as $dep) {
-    $path = trim((string) shell_exec('command -v ' . escapeshellarg($dep) . ' 2>/dev/null'));
+    $path = trim((string) shell_exec(sprintf('command -v %s 2>/dev/null', escapeshellarg($dep))));
     if ($path === '') {
       $missing[] = $dep;
     }
@@ -439,7 +439,7 @@ function removeDir(string $directory): void {
  * @param string $file
  *   Path to the file to remove.
  */
-function cleanupFile(string $file): void {
+function removeFile(string $file): void {
   if (is_file($file)) {
     unlink($file);
   }

--- a/.scaffold/assets/update-assets.php
+++ b/.scaffold/assets/update-assets.php
@@ -31,7 +31,6 @@
 
 declare(strict_types=1);
 
-// Terminal dimensions for the recording.
 define('TERMINAL_COLS', 80);
 define('TERMINAL_ROWS', 24);
 
@@ -459,7 +458,6 @@ function verbose(string $message): void {
   fwrite(STDOUT, $message . PHP_EOL);
 }
 
-// Entrypoint.
 if (getenv('SCRIPT_RUN_SKIP') !== '1' && PHP_SAPI === 'cli' && empty($_SERVER['REMOTE_ADDR'])) {
   ini_set('display_errors', '1');
 

--- a/.scaffold/docs/tests/unit/AsciinemaPlayer/AsciinemaPlayer.test.js
+++ b/.scaffold/docs/tests/unit/AsciinemaPlayer/AsciinemaPlayer.test.js
@@ -517,7 +517,6 @@ describe('AsciinemaPlayer Component', () => {
 
   describe('Library Integration', () => {
     beforeEach(() => {
-      // Clean up window/document for each test if they exist.
       if (typeof window !== 'undefined' && window.AsciinemaPlayer) {
         delete window.AsciinemaPlayer;
       }
@@ -533,14 +532,12 @@ describe('AsciinemaPlayer Component', () => {
       // Wait for useEffect.
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Should add CSS link.
       const cssLink = document.head.querySelector(
         'link[href*="asciinema-player.css"]'
       );
       expect(cssLink).toBeInTheDocument();
       expect(cssLink.rel).toBe('stylesheet');
 
-      // Should add JS script.
       const jsScript = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
@@ -548,7 +545,6 @@ describe('AsciinemaPlayer Component', () => {
     });
 
     test('does not duplicate CSS links', async () => {
-      // First render.
       render(
         <AsciinemaPlayer
           src="/fixtures/test-cast.json"
@@ -557,7 +553,6 @@ describe('AsciinemaPlayer Component', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Second render.
       render(
         <AsciinemaPlayer
           src="/fixtures/test-cast.json"
@@ -566,7 +561,6 @@ describe('AsciinemaPlayer Component', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Should only have one CSS link.
       const cssLinks = document.head.querySelectorAll(
         'link[href*="asciinema-player.css"]'
       );
@@ -581,19 +575,15 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Simulate library not existing initially.
       expect(window.AsciinemaPlayer).toBeUndefined();
 
-      // Find the script and simulate its onload.
       const script = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
       expect(script).toBeInTheDocument();
 
-      // Mock the library being available after script loads.
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // Trigger the onload handler.
       if (script.onload) {
         script.onload();
       }
@@ -618,7 +608,6 @@ describe('AsciinemaPlayer Component', () => {
     test('creates player when library already exists', async () => {
       const mockCreate = jest.fn();
 
-      // Pre-load the library.
       window.AsciinemaPlayer = { create: mockCreate };
 
       const { container } = render(
@@ -655,7 +644,6 @@ describe('AsciinemaPlayer Component', () => {
       const mockCreate = jest.fn();
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // With poster but no startAt.
       const { rerender, container } = render(
         <AsciinemaPlayer src="/fixtures/test-cast.json" poster="npt:1:00" />
       );
@@ -679,7 +667,6 @@ describe('AsciinemaPlayer Component', () => {
 
       jest.clearAllMocks();
 
-      // With startAt but no poster.
       rerender(<AsciinemaPlayer src="/fixtures/test-cast.json" startAt={30} />);
 
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -703,7 +690,6 @@ describe('AsciinemaPlayer Component', () => {
     test('handles errors during library loading', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
-      // Force an error by making querySelector throw.
       const originalQuerySelector = document.querySelector;
       document.querySelector = jest.fn().mockImplementation(() => {
         throw new Error('Mock error');
@@ -715,16 +701,13 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Should still render the container.
       expect(container.firstChild).toBeInTheDocument();
 
-      // Should log the error.
       expect(consoleSpy).toHaveBeenCalledWith(
         'Failed to load Asciinema player:',
         expect.any(Error)
       );
 
-      // Restore.
       document.querySelector = originalQuerySelector;
       consoleSpy.mockRestore();
     });
@@ -737,16 +720,13 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Find the script and simulate its onload (library not yet available).
       const script = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
       expect(script).toBeInTheDocument();
 
-      // Mock the library being available after script loads.
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // Trigger the onload handler to cover the startAt assignment.
       if (script.onload) {
         script.onload();
       }

--- a/.scaffold/tests/bats/_helper.bash
+++ b/.scaffold/tests/bats/_helper.bash
@@ -8,12 +8,10 @@
 setup() {
   [ ! -d ".git" ] && echo "Tests must be run from the repository root directory." && exit 1
 
-  # Setup libraries.
   export BATS_LIB_PATH="${BATS_TEST_DIRNAME}/node_modules"
   bats_load_library bats-helpers
   mock_setup
 
-  # Print debug information if "--verbose-run" is passed.
   # LCOV_EXCL_START
   if [ "${BATS_VERBOSE_RUN-}" = "1" ]; then
     echo "BUILD_DIR: ${BUILD_DIR}" >&3

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -11,8 +11,8 @@
 load _helper
 load "../../../init.sh"
 
-@test "Test all conversions" {
-  input="I am a_string-With spaces 13"
+@test "convert_string converts to each conversion type" {
+  local input="I am a_string-With spaces 13"
 
   TEST_CASES=(
     "$input" "file_name" "i_am_a_string-with_spaces_13"
@@ -36,7 +36,7 @@ load "../../../init.sh"
   dataprovider_run "convert_string" 3
 }
 
-@test "Test to_pascalcase conversions" {
+@test "to_pascalcase converts strings to PascalCase" {
   TEST_CASES=(
     "my-awesome-project" "MyAwesomeProject"
     "my_awesome_project" "MyAwesomeProject"
@@ -129,7 +129,7 @@ RENOVATE
   assert_file_contains "${tmpdir}/renovate.json" '"matchManagers": []'
 }
 
-@test "cleanup_renovate_managers removes empty matchManagers block" {
+@test "remove_renovate_managers removes empty matchManagers block" {
   local tmpdir="${BATS_TEST_TMPDIR}/cleanup"
   mkdir -p "${tmpdir}"
   create_renovate_json "${tmpdir}"
@@ -137,7 +137,7 @@ RENOVATE
   pushd "${tmpdir}" >/dev/null || return 1
   remove_php
   remove_nodejs
-  cleanup_renovate_managers
+  remove_renovate_managers
   popd >/dev/null || return 1
 
   assert_file_not_contains "${tmpdir}/renovate.json" '"matchManagers"'
@@ -145,14 +145,14 @@ RENOVATE
   assert_file_contains "${tmpdir}/renovate.json" '"matchPackageNames"'
 }
 
-@test "cleanup_renovate_managers no-ops when matchManagers is not empty" {
+@test "remove_renovate_managers no-ops when matchManagers is not empty" {
   local tmpdir="${BATS_TEST_TMPDIR}/cleanup_noop"
   mkdir -p "${tmpdir}"
   create_renovate_json "${tmpdir}"
 
   pushd "${tmpdir}" >/dev/null || return 1
   remove_php
-  cleanup_renovate_managers
+  remove_renovate_managers
   popd >/dev/null || return 1
 
   assert_file_contains "${tmpdir}/renovate.json" '"matchManagers": ["npm"]'
@@ -167,18 +167,18 @@ Invoke the update-consumer-scaffold skill
 ask Claude Code to "update scaffold"
 AGENTS
 
-  pushd "${tmpdir}" >/dev/null || exit 1
+  pushd "${tmpdir}" >/dev/null || return 1
   protect_skill_references
-  popd >/dev/null || exit 1
+  popd >/dev/null || return 1
 
   assert_file_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL_URL__'
   assert_file_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL_NAME__'
   assert_file_contains "${tmpdir}/AGENTS.md" '__SCAFFOLD_SKILL_TRIGGER__'
   assert_file_not_contains "${tmpdir}/AGENTS.md" 'AlexSkrypnyk/scaffold'
 
-  pushd "${tmpdir}" >/dev/null || exit 1
+  pushd "${tmpdir}" >/dev/null || return 1
   restore_skill_references
-  popd >/dev/null || exit 1
+  popd >/dev/null || return 1
 
   assert_file_contains "${tmpdir}/AGENTS.md" 'https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md'
   assert_file_contains "${tmpdir}/AGENTS.md" 'Invoke the update-consumer-scaffold skill'
@@ -320,7 +320,7 @@ TOKENS
   assert_file_not_contains "${tmpdir}/AGENTS.md" "AI_ARCH_DOCS_MERMAID"
 }
 
-@test "process_ai_arch_docs keeps both formats when the feature is off" {
+@test "process_ai_arch_docs keeps both formats when none is selected" {
   local tmpdir="${BATS_TEST_TMPDIR}/process_arch_none"
   mkdir -p "${tmpdir}"
   create_ai_arch_docs_tokens "${tmpdir}"
@@ -554,7 +554,7 @@ TOKENS
   assert_output_contains "Missing required option"
 }
 
-@test "normalize_inputs canonicalises identity values" {
+@test "normalize_inputs canonicalizes identity values" {
   namespace="Acme App"
   project="Acme App"
   author="Jane Doe"
@@ -573,7 +573,7 @@ TOKENS
   assert_output_contains "acme-app"
 }
 
-@test "collect_noninteractive honours the script sub-mode" {
+@test "collect_noninteractive honors the script sub-mode" {
   parse_args --namespace=AcmeApp --name=acme-app --author="Jane Doe" --php-script
   run collect_noninteractive
   assert_success
@@ -781,7 +781,7 @@ SETTINGS
   assert_file_contains "${tmpdir}/.claude/settings.json" "composer:"
 }
 
-@test "process_claude_settings is a no-op when the settings file is absent" {
+@test "process_claude_settings no-ops when the settings file is absent" {
   local tmpdir="${BATS_TEST_TMPDIR}/claude_absent"
   mkdir -p "${tmpdir}"
 
@@ -890,7 +890,7 @@ SETTINGS
   archive_ref="1.2.3"
   run resolve_archive_url
   assert_success
-  assert_equal "${output}" "file:///tmp/local.tar.gz"
+  assert_output "file:///tmp/local.tar.gz"
 }
 
 @test "resolve_archive_url builds an archive URL from --ref" {
@@ -898,7 +898,7 @@ SETTINGS
   archive_ref="feature-x"
   run resolve_archive_url
   assert_success
-  assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/feature-x.tar.gz"
+  assert_output "https://github.com/AlexSkrypnyk/scaffold/archive/feature-x.tar.gz"
 }
 
 @test "resolve_archive_url uses the latest release tag by default" {
@@ -907,7 +907,7 @@ SETTINGS
   curl() { echo '{"tag_name": "9.9.9"}'; }
   run resolve_archive_url
   assert_success
-  assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/refs/tags/9.9.9.tar.gz"
+  assert_output "https://github.com/AlexSkrypnyk/scaffold/archive/refs/tags/9.9.9.tar.gz"
 }
 
 @test "resolve_archive_url falls back to main when no release is found" {
@@ -916,13 +916,13 @@ SETTINGS
   curl() { return 1; }
   run resolve_archive_url
   assert_success
-  assert_equal "${output}" "https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz"
+  assert_output "https://github.com/AlexSkrypnyk/scaffold/archive/refs/heads/main.tar.gz"
 }
 
 create_template_tarball() {
   local out="${1}"
   local with_scaffold="${2:-1}"
-  local src="${BATS_TEST_TMPDIR}/tpl-src"
+  local src="${BATS_TEST_TMPDIR}/template_src"
   rm -rf "${src}"
   mkdir -p "${src}/pkg"
   touch "${src}/pkg/composer.json"
@@ -937,7 +937,7 @@ create_template_tarball() {
   local archive="${BATS_TEST_TMPDIR}/valid.tar.gz"
   create_template_tarball "${archive}" 1
 
-  local target="${BATS_TEST_TMPDIR}/valid-target"
+  local target="${BATS_TEST_TMPDIR}/valid_target"
   mkdir -p "${target}"
 
   pushd "${target}" >/dev/null || return 1
@@ -950,11 +950,11 @@ create_template_tarball() {
   assert_dir_not_exists "${target}/.scaffold-bootstrap"
 }
 
-@test "fetch_and_stage_template rejects an archive without .scaffold" {
+@test "fetch_and_stage_template fails on an archive without .scaffold" {
   local archive="${BATS_TEST_TMPDIR}/invalid.tar.gz"
   create_template_tarball "${archive}" 0
 
-  local target="${BATS_TEST_TMPDIR}/invalid-target"
+  local target="${BATS_TEST_TMPDIR}/invalid_target"
   mkdir -p "${target}"
 
   pushd "${target}" >/dev/null || return 1
@@ -968,7 +968,7 @@ create_template_tarball() {
 }
 
 @test "fetch_and_stage_template fails when the download fails" {
-  local target="${BATS_TEST_TMPDIR}/download-fail-target"
+  local target="${BATS_TEST_TMPDIR}/download_fail_target"
   mkdir -p "${target}"
 
   pushd "${target}" >/dev/null || return 1

--- a/.scaffold/tests/bats/init.bats
+++ b/.scaffold/tests/bats/init.bats
@@ -517,6 +517,11 @@ TOKENS
   assert_equal "${interactive}" "0"
 }
 
+@test "parse_args --ref sets the bootstrap ref" {
+  parse_args --ref=1.2.3
+  assert_equal "${archive_ref}" "1.2.3"
+}
+
 @test "parse_args fails on conflicting PHP sub-modes" {
   run parse_args --php-command --php-script
   assert_failure
@@ -833,11 +838,6 @@ SETTINGS
   assert_file_not_exists "${tmpdir}/README.dist.md"
   assert_file_exists "${tmpdir}/CONTRIBUTING.md"
   assert_file_not_exists "${tmpdir}/CONTRIBUTING.dist.md"
-}
-
-@test "parse_args --ref sets the bootstrap ref" {
-  parse_args --ref=1.2.3
-  assert_equal "${archive_ref}" "1.2.3"
 }
 
 @test "template_present detects the .scaffold directory" {

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/tests/unit/AsciinemaPlayer/AsciinemaPlayer.test.js
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/docs/tests/unit/AsciinemaPlayer/AsciinemaPlayer.test.js
@@ -517,7 +517,6 @@ describe('AsciinemaPlayer Component', () => {
 
   describe('Library Integration', () => {
     beforeEach(() => {
-      // Clean up window/document for each test if they exist.
       if (typeof window !== 'undefined' && window.AsciinemaPlayer) {
         delete window.AsciinemaPlayer;
       }
@@ -533,14 +532,12 @@ describe('AsciinemaPlayer Component', () => {
       // Wait for useEffect.
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Should add CSS link.
       const cssLink = document.head.querySelector(
         'link[href*="asciinema-player.css"]'
       );
       expect(cssLink).toBeInTheDocument();
       expect(cssLink.rel).toBe('stylesheet');
 
-      // Should add JS script.
       const jsScript = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
@@ -548,7 +545,6 @@ describe('AsciinemaPlayer Component', () => {
     });
 
     test('does not duplicate CSS links', async () => {
-      // First render.
       render(
         <AsciinemaPlayer
           src="/fixtures/test-cast.json"
@@ -557,7 +553,6 @@ describe('AsciinemaPlayer Component', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Second render.
       render(
         <AsciinemaPlayer
           src="/fixtures/test-cast.json"
@@ -566,7 +561,6 @@ describe('AsciinemaPlayer Component', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Should only have one CSS link.
       const cssLinks = document.head.querySelectorAll(
         'link[href*="asciinema-player.css"]'
       );
@@ -581,19 +575,15 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Simulate library not existing initially.
       expect(window.AsciinemaPlayer).toBeUndefined();
 
-      // Find the script and simulate its onload.
       const script = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
       expect(script).toBeInTheDocument();
 
-      // Mock the library being available after script loads.
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // Trigger the onload handler.
       if (script.onload) {
         script.onload();
       }
@@ -618,7 +608,6 @@ describe('AsciinemaPlayer Component', () => {
     test('creates player when library already exists', async () => {
       const mockCreate = jest.fn();
 
-      // Pre-load the library.
       window.AsciinemaPlayer = { create: mockCreate };
 
       const { container } = render(
@@ -655,7 +644,6 @@ describe('AsciinemaPlayer Component', () => {
       const mockCreate = jest.fn();
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // With poster but no startAt.
       const { rerender, container } = render(
         <AsciinemaPlayer src="/fixtures/test-cast.json" poster="npt:1:00" />
       );
@@ -679,7 +667,6 @@ describe('AsciinemaPlayer Component', () => {
 
       jest.clearAllMocks();
 
-      // With startAt but no poster.
       rerender(<AsciinemaPlayer src="/fixtures/test-cast.json" startAt={30} />);
 
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -703,7 +690,6 @@ describe('AsciinemaPlayer Component', () => {
     test('handles errors during library loading', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
-      // Force an error by making querySelector throw.
       const originalQuerySelector = document.querySelector;
       document.querySelector = jest.fn().mockImplementation(() => {
         throw new Error('Mock error');
@@ -715,16 +701,13 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Should still render the container.
       expect(container.firstChild).toBeInTheDocument();
 
-      // Should log the error.
       expect(consoleSpy).toHaveBeenCalledWith(
         'Failed to load Asciinema player:',
         expect.any(Error)
       );
 
-      // Restore.
       document.querySelector = originalQuerySelector;
       consoleSpy.mockRestore();
     });
@@ -737,16 +720,13 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Find the script and simulate its onload (library not yet available).
       const script = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
       expect(script).toBeInTheDocument();
 
-      // Mock the library being available after script loads.
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // Trigger the onload handler to cover the startAt assignment.
       if (script.onload) {
         script.onload();
       }

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/force-crystal.sh
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/force-crystal.sh
@@ -13,10 +13,8 @@
 set -euo pipefail
 [ "${SCRIPT_DEBUG-}" = "1" ] && set -x
 
-# URL endpoint to fetch the data from.
 URL_ENDPOINT="${JOKE_URL_ENDPOINT:-https://official-joke-api.appspot.com/jokes/__TOPIC__/random}"
 
-# Topic.
 topic="${1-}"
 
 # Flag to bypass the prompt to proceed.
@@ -87,9 +85,7 @@ main() {
   echo
 
   response="$(curl -sL "${url}")"
-  # Extract 'setup'
   setup=$(echo "${response}" | sed -E 's/.*"setup":"([^"]+)".*/\1/')
-  # Extract 'punchline'
   punchline=$(echo "${response}" | sed -E 's/.*"punchline":"([^"]+)".*/\1/')
 
   echo "$setup"

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/nodejs-script
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/nodejs-script
@@ -9,12 +9,12 @@
  * external packages.
  *
  * To adopt script template:
- * - Replace "NodeJS CLI script template" with your script human name.
- * - Replace "nodejs-script" with your script file name.
- * - Update arguments count check to suit your needs.
- * - Update printHelp() function with your content.
- * - Copy '/tests/nodejs' directory into your project and update
- *   script.test.js to a script file name.
+ * - Replace "NodeJS CLI script template" with the script's human name.
+ * - Replace "nodejs-script" with the script's file name.
+ * - Update the argument count check as needed.
+ * - Update the printHelp() content.
+ * - Copy '/tests/nodejs' directory into the project and update
+ *   script.test.js to the script's file name.
  * - Remove this block of comments.
  * -----------------------------------------------------------------------------
  *
@@ -59,7 +59,7 @@ function main(argv, argc) {
     throw new Error('Please provide a value of the first argument.');
   }
 
-  // Add your logic here.
+  // Add the script logic here.
   verbose(`Would execute script business logic with argument ${argv[1]}.`);
 }
 
@@ -96,8 +96,8 @@ Examples:
 function verbose(string) {
   buffer.push(string);
 
-  // Treat an unset or '0' value as "not quiet", mirroring a loose emptiness
-  // check, so that only an explicit non-'0' value suppresses the output.
+  // Treat an unset or '0' value as not quiet, so only an explicit non-'0'
+  // value suppresses the output.
   const quiet = process.env.SCRIPT_QUIET;
   if (!quiet || quiet === '0') {
     /* c8 ignore next */
@@ -107,15 +107,13 @@ function verbose(string) {
   return buffer;
 }
 
-// Entrypoint.
-//
 /* c8 ignore start */
 if (require.main === module && process.env.SCRIPT_RUN_SKIP !== '1') {
   try {
     // Drop the Node executable and keep the script path as the first element,
     // so that argv[1] is the first user-provided argument.
     const argv = process.argv.slice(1);
-    // The function should not provide an exit code but rather throw errors.
+    // main() throws on error instead of returning an exit code.
     main(argv, argv.length);
   } catch (error) {
     verbose(`\nERROR: ${error.message}\n`);

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/src/Command/JokeCommand.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/src/Command/JokeCommand.php
@@ -12,9 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Joke command.
  *
- * Allows to get a random joke.
- *
- * @package YodasHut\App\Command
+ * Retrieves a random joke.
  */
 class JokeCommand extends Command {
 

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/src/Command/SayHelloCommand.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/src/Command/SayHelloCommand.php
@@ -10,10 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Say hello command.
- *
- * Allows to say hello.
- *
- * @package YodasHut\App\Command
  */
 class SayHelloCommand extends Command {
 

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/_helper.bash
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/_helper.bash
@@ -12,34 +12,28 @@
 setup() {
   [ ! -d ".git" ] && echo "Tests must be run from the repository root directory." && exit 1
 
-  # For a list of available variables see:
+  # Available BATS variables:
   # @see https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 
-  # Register a path to libraries.
   export BATS_LIB_PATH="${BATS_TEST_DIRNAME}/node_modules"
 
-  # Load 'bats-helpers' library.
   bats_load_library bats-helpers
 
-  # Setup command mocking.
   mock_setup
 
-  # Current directory where the test is run from.
   # shellcheck disable=SC2155
   export CUR_DIR="$(pwd)"
 
   # Project directory root (where .git is located).
   export ROOT_DIR="${CUR_DIR}"
 
-  # Directory where the shell command script will be running in.
+  # Directory where the shell command script runs.
   export BUILD_DIR="${BUILD_DIR:-"${BATS_TEST_TMPDIR//\/\//\/}/shell-$(date +%s)"}"
   fixture_prepare_dir "${BUILD_DIR}"
 
-  # Copy codebase at the last commit into the BUILD_DIR.
-  # Tests requiring to work with the copy of the codebase should opt-in using
-  # BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
-  # Note that during development of tests the local changes need to be
-  # committed.
+  # Copy the codebase at the last commit into BUILD_DIR. Tests that work with
+  # the copy opt in with BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
+  # During test development, local changes must be committed.
   fixture_export_codebase "${BUILD_DIR}" "${ROOT_DIR}"
 
   # Print debug information if "--verbose-run" is passed.
@@ -56,6 +50,5 @@ setup() {
 }
 
 teardown() {
-  # Move back to the original directory.
   popd >/dev/null || cd "${CUR_DIR}" || exit 1
 }

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/JokeCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/JokeCommandTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use YodasHut\App\Command\JokeCommand;
 
 /**
- * Unit test for the JokeCommand class.
+ * Functional test for the JokeCommand class.
  */
 #[CoversMethod(JokeCommand::class, 'execute')]
 #[CoversMethod(JokeCommand::class, 'configure')]

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/JokeCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/JokeCommandTest.php
@@ -13,9 +13,7 @@ use PHPUnit\Framework\TestCase;
 use YodasHut\App\Command\JokeCommand;
 
 /**
- * Class JokeCommandTest.
- *
- * This is a unit test for the JokeCommand class.
+ * Unit test for the JokeCommand class.
  */
 #[CoversMethod(JokeCommand::class, 'execute')]
 #[CoversMethod(JokeCommand::class, 'configure')]

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/SayHelloCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/SayHelloCommandTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use YodasHut\App\Command\SayHelloCommand;
 
 /**
- * Unit test for the SayHelloCommand class.
+ * Functional test for the SayHelloCommand class.
  */
 #[CoversMethod(SayHelloCommand::class, 'execute')]
 #[CoversMethod(SayHelloCommand::class, 'configure')]

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/SayHelloCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/phpunit/Functional/SayHelloCommandTest.php
@@ -12,9 +12,7 @@ use PHPUnit\Framework\TestCase;
 use YodasHut\App\Command\SayHelloCommand;
 
 /**
- * Class SayHelloCommandTest.
- *
- * This is a unit test for the SayHelloCommand class.
+ * Unit test for the SayHelloCommand class.
  */
 #[CoversMethod(SayHelloCommand::class, 'execute')]
 #[CoversMethod(SayHelloCommand::class, 'configure')]

--- a/.scaffold/tests/phpunit/fixtures/init/name/src/Command/JokeCommand.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/src/Command/JokeCommand.php
@@ -7,12 +7,3 @@
  
  use Symfony\Component\Console\Command\Command;
  use Symfony\Component\Console\Input\InputInterface;
-@@ -14,7 +14,7 @@
-  *
-  * Allows to get a random joke.
-  *
-- * @package YodasHut\App\Command
-+ * @package JediTemple\App\Command
-  */
- class JokeCommand extends Command {
- 

--- a/.scaffold/tests/phpunit/fixtures/init/name/src/Command/SayHelloCommand.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/src/Command/SayHelloCommand.php
@@ -7,12 +7,3 @@
  
  use Symfony\Component\Console\Command\Command;
  use Symfony\Component\Console\Input\InputInterface;
-@@ -13,7 +13,7 @@
-  *
-  * Allows to say hello.
-  *
-- * @package YodasHut\App\Command
-+ * @package JediTemple\App\Command
-  */
- class SayHelloCommand extends Command {
- 

--- a/.scaffold/tests/phpunit/fixtures/init/name/star-forge.sh
+++ b/.scaffold/tests/phpunit/fixtures/init/name/star-forge.sh
@@ -13,10 +13,8 @@
 set -euo pipefail
 [ "${SCRIPT_DEBUG-}" = "1" ] && set -x
 
-# URL endpoint to fetch the data from.
 URL_ENDPOINT="${JOKE_URL_ENDPOINT:-https://official-joke-api.appspot.com/jokes/__TOPIC__/random}"
 
-# Topic.
 topic="${1-}"
 
 # Flag to bypass the prompt to proceed.
@@ -87,9 +85,7 @@ main() {
   echo
 
   response="$(curl -sL "${url}")"
-  # Extract 'setup'
   setup=$(echo "${response}" | sed -E 's/.*"setup":"([^"]+)".*/\1/')
-  # Extract 'punchline'
   punchline=$(echo "${response}" | sed -E 's/.*"punchline":"([^"]+)".*/\1/')
 
   echo "$setup"

--- a/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/JokeCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/JokeCommandTest.php
@@ -15,4 +15,4 @@
 +use JediTemple\App\Command\JokeCommand;
  
  /**
-  * Class JokeCommandTest.
+  * Unit test for the JokeCommand class.

--- a/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/JokeCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/JokeCommandTest.php
@@ -15,4 +15,4 @@
 +use JediTemple\App\Command\JokeCommand;
  
  /**
-  * Unit test for the JokeCommand class.
+  * Functional test for the JokeCommand class.

--- a/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/SayHelloCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/SayHelloCommandTest.php
@@ -15,4 +15,4 @@
 +use JediTemple\App\Command\SayHelloCommand;
  
  /**
-  * Unit test for the SayHelloCommand class.
+  * Functional test for the SayHelloCommand class.

--- a/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/SayHelloCommandTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/name/tests/phpunit/Functional/SayHelloCommandTest.php
@@ -15,4 +15,4 @@
 +use JediTemple\App\Command\SayHelloCommand;
  
  /**
-  * Class SayHelloCommandTest.
+  * Unit test for the SayHelloCommand class.

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/force-crystal
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/force-crystal
@@ -1,4 +1,4 @@
-@@ -3,37 +3,140 @@
+@@ -3,37 +3,139 @@
  
  /**
   * @file
@@ -130,7 +130,6 @@
  
 -$command = new SayHelloCommand();
 -$application->add($command);
-+// Allow to skip the script run.
 +if (getenv('SCRIPT_RUN_SKIP') != 1) {
 +  set_error_handler(function (int $severity, string $message, string $file, int $line): bool {
 +    if (!(error_reporting() & $severity)) {
@@ -145,7 +144,7 @@
 +  try {
 +    $argv = is_array($_SERVER['argv'] ?? NULL) ? array_filter($_SERVER['argv'], 'is_string') : [];
 +    $argc = is_scalar($_SERVER['argc'] ?? NULL) ? (int) $_SERVER['argc'] : 0;
-+    // The function should not provide an exit code but rather throw exceptions.
++    // main() throws exceptions instead of returning an exit code.
 +    main($argv, $argc);
 +  }
 +  catch (\ErrorException $exception) {

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Functional/ExampleScriptFunctionalTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Functional/ExampleScriptFunctionalTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
- * Class ExampleScriptFunctionalTest.
- *
  * Functional tests for force-crystal.
  */
 #[CoversFunction('main')]

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Functional/ScriptFunctionalTestCase.php
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Functional/ScriptFunctionalTestCase.php
@@ -7,8 +7,6 @@ namespace YodasHut\App\Tests\Functional;
 use YodasHut\App\Tests\Unit\ScriptUnitTestCase;
 
 /**
- * Class ScriptFunctionalTestCase.
- *
  * Base class to functional test scripts.
  */
 abstract class ScriptFunctionalTestCase extends ScriptUnitTestCase {
@@ -29,9 +27,7 @@ abstract class ScriptFunctionalTestCase extends ScriptUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    // Allow script to run.
     putenv('SCRIPT_RUN_SKIP=0');
-    // Log output into stdout.
     putenv('SCRIPT_QUIET=0');
   }
 

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Unit/ExampleScriptUnitTest.php
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Unit/ExampleScriptUnitTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Class ExampleScriptUnitTest.
- *
  * Unit tests for force-crystal.
  */
 #[CoversFunction('main')]

--- a/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Unit/ScriptUnitTestCase.php
+++ b/.scaffold/tests/phpunit/fixtures/init/php_script/tests/phpunit/Unit/ScriptUnitTestCase.php
@@ -8,8 +8,6 @@ use AlexSkrypnyk\PhpunitHelpers\Traits\AssertArrayTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class ScriptUnitTestCase.
- *
  * Base class to unit test scripts.
  */
 abstract class ScriptUnitTestCase extends TestCase {
@@ -27,9 +25,8 @@ abstract class ScriptUnitTestCase extends TestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    // Prevent script from running.
     putenv('SCRIPT_RUN_SKIP=1');
-    // Log output into internal buffer instead of stdout so we can assert it.
+    // Log output into internal buffer instead of stdout so tests can assert it.
     putenv('SCRIPT_QUIET=1');
 
     if (!is_readable(static::$script)) {

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -309,10 +309,9 @@ final class InitTest extends UnitTestCase {
   public function testInitViaCurlBootstrapsIntoEmptyDir(): void {
     self::$fixtures = NULL;
 
-    // Build a template archive from the pristine SUT copy. GitHub archives nest
-    // everything under a top-level directory, so archive the SUT under its own
-    // basename and strip that component on extraction, exactly as init.sh does
-    // against a real GitHub tarball.
+    // GitHub archives nest everything under a top-level directory, so the
+    // pristine SUT copy is archived under its own basename. init.sh strips
+    // that component on extraction, as with a real GitHub tarball.
     $archive = self::$tmp . DIRECTORY_SEPARATOR . 'scaffold.tar.gz';
     $this->processRun('tar', ['-czf', $archive, '-C', dirname(self::$sut), basename(self::$sut)]);
     $this->assertProcessSuccessful();
@@ -348,8 +347,8 @@ final class InitTest extends UnitTestCase {
   /**
    * Bootstrapping refuses to run in a directory that already has files.
    *
-   * A non-empty current directory must abort before anything is downloaded, so
-   * pre-existing files are never clobbered.
+   * The run must abort before anything is downloaded when the current
+   * directory is not empty, so pre-existing files are never clobbered.
    */
   public function testInitViaCurlBootstrapRefusesNonEmptyDir(): void {
     self::$fixtures = NULL;
@@ -385,9 +384,9 @@ final class InitTest extends UnitTestCase {
    *
    * `curl ... | bash` with no options must download and extract the template
    * and then re-run to prompt the user. The test environment has no terminal,
-   * so the prompt has nothing to read and the run aborts cleanly - proving the
-   * bootstrap completed and control reached the interactive collector (a real
-   * user with a terminal answers the prompts instead).
+   * so the prompt has nothing to read and the run aborts cleanly. The clean
+   * abort proves the bootstrap completed and control reached the interactive
+   * collector; a real user with a terminal answers the prompts instead.
    */
   public function testInitViaCurlBootstrapsThenPromptsWithoutOptions(): void {
     self::$fixtures = NULL;
@@ -416,9 +415,10 @@ final class InitTest extends UnitTestCase {
   /**
    * An archive without a '.scaffold' leaves the target directory clean.
    *
-   * The download is staged and validated before anything is promoted, so an
-   * archive that is not a Scaffold (or a partial extraction) must abort without
-   * leaving debris that would trip the empty-directory guard on a retry.
+   * The download is staged and validated before anything is promoted. An
+   * archive that is not a Scaffold (or a partial extraction) must abort the
+   * run without leaving debris that would trip the empty-directory guard on
+   * a retry.
    */
   public function testInitViaCurlBootstrapCleansUpInvalidArchive(): void {
     self::$fixtures = NULL;
@@ -456,8 +456,8 @@ final class InitTest extends UnitTestCase {
    *
    * The bulk `scaffold` -> project rewrite in init.sh would otherwise
    * mangle the self-update skill URL, name, and trigger. They are
-   * token-protected, so a regression here must fail loudly rather than
-   * being silently re-baselined.
+   * token-protected, so a regression here must fail rather than be
+   * silently re-baselined.
    */
   public function testInitPreservesUpdateSkillReferences(): void {
     self::$fixtures = NULL;
@@ -486,7 +486,7 @@ final class InitTest extends UnitTestCase {
    * The bulk `scaffold` -> project rewrite in init.sh would otherwise
    * mangle the README footer link text and domain into a project-named URL
    * that does not exist. The phrase is token-protected, so a regression must
-   * fail loudly rather than being silently re-baselined.
+   * fail rather than be silently re-baselined.
    */
   public function testInitPreservesAttributionFooter(): void {
     self::$fixtures = NULL;
@@ -511,8 +511,8 @@ final class InitTest extends UnitTestCase {
    * init.sh must not delete LICENSE: without it GitHub cannot detect the
    * project's license and the README badge renders "not identified", while
    * composer.json and package.json still declare GPL-3.0-or-later. A
-   * regression here must fail loudly rather than being silently re-baselined
-   * by update-snapshots.
+   * regression here must fail rather than be silently re-baselined by
+   * update-snapshots.
    */
   public function testInitKeepsLicense(): void {
     self::$fixtures = NULL;

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -58,6 +58,137 @@ final class InitTest extends UnitTestCase {
     }
   }
 
+  public static function dataProviderInit(): \Iterator {
+    yield self::BASELINE_DATASET => [
+        [],
+    ];
+    yield 'name' => [
+        [
+          'namespace' => 'JediTemple',
+          'project' => 'star-forge',
+          'author' => 'Obi-Wan Kenobi',
+        ],
+    ];
+    yield 'php command' => [
+        [
+          'use_php' => self::$tuiYes,
+          'use_php_command' => self::$tuiYes,
+          'php_command_name' => 'star-forge',
+          'use_nodejs' => self::$tuiNo,
+          'use_shell' => self::$tuiNo,
+        ],
+    ];
+    yield 'php script' => [
+        [
+          'use_php' => self::$tuiYes,
+          'use_php_command' => self::$tuiNo,
+          'use_php_script' => self::$tuiYes,
+          'use_nodejs' => self::$tuiNo,
+          'use_shell' => self::$tuiNo,
+        ],
+    ];
+    yield 'nodejs' => [
+        [
+          'use_php' => self::$tuiNo,
+          'use_nodejs' => self::$tuiYes,
+          'use_shell' => self::$tuiNo,
+        ],
+    ];
+    yield 'shell' => [
+        [
+          'use_php' => self::$tuiNo,
+          'use_nodejs' => self::$tuiNo,
+          'use_shell' => self::$tuiYes,
+        ],
+    ];
+    yield 'no languages' => [
+        [
+          'use_php' => self::$tuiNo,
+          'use_php_command' => self::TUI_SKIP,
+          'php_command_name' => self::TUI_SKIP,
+          'use_php_command_build' => self::TUI_SKIP,
+          'use_php_script' => self::TUI_SKIP,
+          'use_nodejs' => self::$tuiNo,
+          'use_shell' => self::$tuiNo,
+        ],
+    ];
+    yield 'docker' => [
+        [
+          'use_php' => self::$tuiNo,
+          'use_php_command' => self::TUI_SKIP,
+          'php_command_name' => self::TUI_SKIP,
+          'use_php_command_build' => self::TUI_SKIP,
+          'use_php_script' => self::TUI_SKIP,
+          'use_nodejs' => self::$tuiNo,
+          'use_shell' => self::$tuiNo,
+          'use_docker' => self::$tuiYes,
+          'docker_image_name' => self::TUI_DEFAULT,
+        ],
+    ];
+    yield 'no release drafter' => [
+        [
+          'use_release_drafter' => self::$tuiNo,
+        ],
+    ];
+    yield 'no pr autoassign' => [
+        [
+          'use_pr_autoassign' => self::$tuiNo,
+        ],
+    ];
+    yield 'no funding' => [
+        [
+          'use_funding' => self::$tuiNo,
+        ],
+    ];
+    yield 'no pr template' => [
+        [
+          'use_pr_template' => self::$tuiNo,
+        ],
+    ];
+    yield 'no renovate' => [
+        [
+          'use_renovate' => self::$tuiNo,
+        ],
+    ];
+    yield 'no docs' => [
+        [
+          'use_docs' => self::$tuiNo,
+        ],
+    ];
+    yield 'test actions' => [
+        [
+          'use_test_actions' => self::$tuiYes,
+        ],
+    ];
+    yield 'no schedule' => [
+        [
+          'use_schedule' => self::$tuiNo,
+        ],
+    ];
+    yield 'no ai' => [
+        [
+          'use_ai' => self::$tuiNo,
+          'use_ai_arch_docs' => self::TUI_SKIP,
+        ],
+    ];
+    yield 'ai arch docs plantuml' => [
+        [
+          'use_ai_arch_docs' => 'plantuml',
+        ],
+    ];
+    yield 'no ai arch docs' => [
+        [
+          'use_ai_arch_docs' => 'none',
+        ],
+    ];
+    yield 'no docs no ai arch docs' => [
+        [
+          'use_docs' => self::$tuiNo,
+          'use_ai_arch_docs' => 'none',
+        ],
+    ];
+  }
+
   /**
    * Non-interactive runs must produce the same result as interactive defaults.
    */
@@ -83,6 +214,43 @@ final class InitTest extends UnitTestCase {
     $diffs = File::dir($fixtures_init . DIRECTORY_SEPARATOR . $diffs_name);
 
     $this->assertSnapshotMatchesBaseline(self::$sut, $baseline, $diffs);
+  }
+
+  public static function dataProviderInitNonInteractive(): \Iterator {
+    $identity = ['--namespace=YodasHut', '--name=force-crystal', '--author=Luke Skywalker'];
+
+    yield 'all defaults' => [
+      $identity,
+      self::BASELINE_DIR,
+    ];
+    yield 'no docs' => [
+      array_merge($identity, ['--no-docs']),
+      'no_docs',
+    ];
+    yield 'test actions' => [
+      array_merge($identity, ['--test-actions']),
+      'test_actions',
+    ];
+    yield 'no schedule' => [
+      array_merge($identity, ['--no-schedule']),
+      'no_schedule',
+    ];
+    yield 'no ai' => [
+      array_merge($identity, ['--no-ai']),
+      'no_ai',
+    ];
+    yield 'ai arch docs plantuml' => [
+      array_merge($identity, ['--ai-arch-docs=plantuml']),
+      'ai_arch_docs_plantuml',
+    ];
+    yield 'no ai arch docs' => [
+      array_merge($identity, ['--no-ai-arch-docs']),
+      'no_ai_arch_docs',
+    ];
+    yield 'no docs no ai arch docs' => [
+      array_merge($identity, ['--no-docs', '--no-ai-arch-docs']),
+      'no_docs_no_ai_arch_docs',
+    ];
   }
 
   /**
@@ -382,13 +550,13 @@ final class InitTest extends UnitTestCase {
    * manual check.
    */
   public function testInitTestActionsPassesZizmor(): void {
+    self::$fixtures = NULL;
+
     $zizmor = (new ExecutableFinder())->find('zizmor');
 
     if (!is_string($zizmor)) {
       $this->markTestSkipped('The "zizmor" binary is not available.');
     }
-
-    self::$fixtures = NULL;
 
     $arguments = ['--namespace=YodasHut', '--name=force-crystal', '--author=Luke Skywalker', '--test-actions'];
     $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', $arguments);
@@ -491,174 +659,6 @@ final class InitTest extends UnitTestCase {
 
     $this->assertFileDoesNotExist(self::$sut . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'settings.json');
     $this->assertDirectoryDoesNotExist(self::$sut . DIRECTORY_SEPARATOR . '.claude');
-  }
-
-  public static function dataProviderInitNonInteractive(): \Iterator {
-    $identity = ['--namespace=YodasHut', '--name=force-crystal', '--author=Luke Skywalker'];
-
-    yield 'all defaults' => [
-      $identity,
-      self::BASELINE_DIR,
-    ];
-    yield 'no docs' => [
-      array_merge($identity, ['--no-docs']),
-      'no_docs',
-    ];
-    yield 'test actions' => [
-      array_merge($identity, ['--test-actions']),
-      'test_actions',
-    ];
-    yield 'no schedule' => [
-      array_merge($identity, ['--no-schedule']),
-      'no_schedule',
-    ];
-    yield 'no ai' => [
-      array_merge($identity, ['--no-ai']),
-      'no_ai',
-    ];
-    yield 'ai arch docs plantuml' => [
-      array_merge($identity, ['--ai-arch-docs=plantuml']),
-      'ai_arch_docs_plantuml',
-    ];
-    yield 'no ai arch docs' => [
-      array_merge($identity, ['--no-ai-arch-docs']),
-      'no_ai_arch_docs',
-    ];
-    yield 'no docs no ai arch docs' => [
-      array_merge($identity, ['--no-docs', '--no-ai-arch-docs']),
-      'no_docs_no_ai_arch_docs',
-    ];
-  }
-
-  public static function dataProviderInit(): \Iterator {
-    yield self::BASELINE_DATASET => [
-        [],
-    ];
-    yield 'name' => [
-        [
-          'namespace' => 'JediTemple',
-          'project' => 'star-forge',
-          'author' => 'Obi-Wan Kenobi',
-        ],
-    ];
-    yield 'php command' => [
-        [
-          'use_php' => self::$tuiYes,
-          'use_php_command' => self::$tuiYes,
-          'php_command_name' => 'star-forge',
-          'use_nodejs' => self::$tuiNo,
-          'use_shell' => self::$tuiNo,
-        ],
-    ];
-    yield 'php script' => [
-        [
-          'use_php' => self::$tuiYes,
-          'use_php_command' => self::$tuiNo,
-          'use_php_script' => self::$tuiYes,
-          'use_nodejs' => self::$tuiNo,
-          'use_shell' => self::$tuiNo,
-        ],
-    ];
-    yield 'nodejs' => [
-        [
-          'use_php' => self::$tuiNo,
-          'use_nodejs' => self::$tuiYes,
-          'use_shell' => self::$tuiNo,
-        ],
-    ];
-    yield 'shell' => [
-        [
-          'use_php' => self::$tuiNo,
-          'use_nodejs' => self::$tuiNo,
-          'use_shell' => self::$tuiYes,
-        ],
-    ];
-    yield 'no languages' => [
-        [
-          'use_php' => self::$tuiNo,
-          'use_php_command' => self::TUI_SKIP,
-          'php_command_name' => self::TUI_SKIP,
-          'use_php_command_build' => self::TUI_SKIP,
-          'use_php_script' => self::TUI_SKIP,
-          'use_nodejs' => self::$tuiNo,
-          'use_shell' => self::$tuiNo,
-        ],
-    ];
-    yield 'docker' => [
-        [
-          'use_php' => self::$tuiNo,
-          'use_php_command' => self::TUI_SKIP,
-          'php_command_name' => self::TUI_SKIP,
-          'use_php_command_build' => self::TUI_SKIP,
-          'use_php_script' => self::TUI_SKIP,
-          'use_nodejs' => self::$tuiNo,
-          'use_shell' => self::$tuiNo,
-          'use_docker' => self::$tuiYes,
-          'docker_image_name' => self::TUI_DEFAULT,
-        ],
-    ];
-    yield 'no release drafter' => [
-        [
-          'use_release_drafter' => self::$tuiNo,
-        ],
-    ];
-    yield 'no pr autoassign' => [
-        [
-          'use_pr_autoassign' => self::$tuiNo,
-        ],
-    ];
-    yield 'no funding' => [
-        [
-          'use_funding' => self::$tuiNo,
-        ],
-    ];
-    yield 'no pr template' => [
-        [
-          'use_pr_template' => self::$tuiNo,
-        ],
-    ];
-    yield 'no renovate' => [
-        [
-          'use_renovate' => self::$tuiNo,
-        ],
-    ];
-    yield 'no docs' => [
-        [
-          'use_docs' => self::$tuiNo,
-        ],
-    ];
-    yield 'test actions' => [
-        [
-          'use_test_actions' => self::$tuiYes,
-        ],
-    ];
-    yield 'no schedule' => [
-        [
-          'use_schedule' => self::$tuiNo,
-        ],
-    ];
-    yield 'no ai' => [
-        [
-          'use_ai' => self::$tuiNo,
-          'use_ai_arch_docs' => self::TUI_SKIP,
-        ],
-    ];
-    yield 'ai arch docs plantuml' => [
-        [
-          'use_ai_arch_docs' => 'plantuml',
-        ],
-    ];
-    yield 'no ai arch docs' => [
-        [
-          'use_ai_arch_docs' => 'none',
-        ],
-    ];
-    yield 'no docs no ai arch docs' => [
-        [
-          'use_docs' => self::$tuiNo,
-          'use_ai_arch_docs' => 'none',
-        ],
-    ];
   }
 
   protected static function defaultAnswers(): array {

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -24,7 +24,7 @@ final class InitTest extends UnitTestCase {
     ?SerializableClosure $before = NULL,
     ?SerializableClosure $after = NULL,
   ): void {
-    self::$fixtures = static::locationsFixtureDir();
+    self::$fixtures = self::locationsFixtureDir();
 
     if ($before instanceof SerializableClosure) {
       $before = self::cu($before);
@@ -408,7 +408,7 @@ final class InitTest extends UnitTestCase {
    * @param list<string> $absent
    *   Permission rules that must be absent from the settings file.
    */
-  #[DataProvider('dataProviderClaudeSettings')]
+  #[DataProvider('dataProviderInitClaudeSettings')]
   public function testInitClaudeSettings(array $arguments, array $present, array $absent): void {
     self::$fixtures = NULL;
 
@@ -439,7 +439,7 @@ final class InitTest extends UnitTestCase {
     $this->assertStringContainsString('/.artifacts/', $gitignore);
   }
 
-  public static function dataProviderClaudeSettings(): \Iterator {
+  public static function dataProviderInitClaudeSettings(): \Iterator {
     // Docker is off by default, so its rules are trimmed unless enabled.
     // Mermaid is the default diagram format, so the PlantUML rule is trimmed
     // unless that format is selected.

--- a/.scaffold/tests/phpunit/src/UnitTestCase.php
+++ b/.scaffold/tests/phpunit/src/UnitTestCase.php
@@ -36,15 +36,14 @@ abstract class UnitTestCase extends UpstreamUnitTestCase {
       '.docusaurus',
     ]);
 
-    // The template ships a shared '.claude/settings.json' and the
-    // 'update-architecture-docs' skill; personal overrides in
-    // '.claude/settings.local.json' are git-ignored and must never leak into a
-    // generated project, so copy only the shipped files (the bulk copy above
-    // skips the whole '.claude' directory to keep local overrides out).
+    // The bulk copy above skips the whole '.claude' directory so the
+    // git-ignored personal overrides in '.claude/settings.local.json' never
+    // leak into a generated project. The template ships a shared
+    // '.claude/settings.json' and the 'update-architecture-docs' skill, so
+    // copy only those shipped files.
     File::copyIfExists(static::locationsRealpath('../../../') . '/.claude/settings.json', static::$sut . '/.claude/settings.json');
     File::copyIfExists(static::locationsRealpath('../../../') . '/.claude/skills/update-architecture-docs/SKILL.md', static::$sut . '/.claude/skills/update-architecture-docs/SKILL.md');
 
-    // Change the current working directory to the 'system under test'.
     chdir(static::$sut);
   }
 

--- a/.scaffold/tests/phpunit/src/UpdateAssetsTest.php
+++ b/.scaffold/tests/phpunit/src/UpdateAssetsTest.php
@@ -51,7 +51,7 @@ final class UpdateAssetsTest extends TestCase {
 
     $header = json_decode($lines[0], TRUE);
     if (!is_array($header)) {
-      $this->fail('Sanitised cast header is not valid JSON.');
+      $this->fail('Sanitized cast header is not valid JSON.');
     }
 
     $this->assertSame('./init.sh', $header['command']);

--- a/docs/tests/unit/AsciinemaPlayer/AsciinemaPlayer.test.js
+++ b/docs/tests/unit/AsciinemaPlayer/AsciinemaPlayer.test.js
@@ -517,7 +517,6 @@ describe('AsciinemaPlayer Component', () => {
 
   describe('Library Integration', () => {
     beforeEach(() => {
-      // Clean up window/document for each test if they exist.
       if (typeof window !== 'undefined' && window.AsciinemaPlayer) {
         delete window.AsciinemaPlayer;
       }
@@ -533,14 +532,12 @@ describe('AsciinemaPlayer Component', () => {
       // Wait for useEffect.
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Should add CSS link.
       const cssLink = document.head.querySelector(
         'link[href*="asciinema-player.css"]'
       );
       expect(cssLink).toBeInTheDocument();
       expect(cssLink.rel).toBe('stylesheet');
 
-      // Should add JS script.
       const jsScript = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
@@ -548,7 +545,6 @@ describe('AsciinemaPlayer Component', () => {
     });
 
     test('does not duplicate CSS links', async () => {
-      // First render.
       render(
         <AsciinemaPlayer
           src="/fixtures/test-cast.json"
@@ -557,7 +553,6 @@ describe('AsciinemaPlayer Component', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Second render.
       render(
         <AsciinemaPlayer
           src="/fixtures/test-cast.json"
@@ -566,7 +561,6 @@ describe('AsciinemaPlayer Component', () => {
       );
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Should only have one CSS link.
       const cssLinks = document.head.querySelectorAll(
         'link[href*="asciinema-player.css"]'
       );
@@ -581,19 +575,15 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Simulate library not existing initially.
       expect(window.AsciinemaPlayer).toBeUndefined();
 
-      // Find the script and simulate its onload.
       const script = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
       expect(script).toBeInTheDocument();
 
-      // Mock the library being available after script loads.
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // Trigger the onload handler.
       if (script.onload) {
         script.onload();
       }
@@ -618,7 +608,6 @@ describe('AsciinemaPlayer Component', () => {
     test('creates player when library already exists', async () => {
       const mockCreate = jest.fn();
 
-      // Pre-load the library.
       window.AsciinemaPlayer = { create: mockCreate };
 
       const { container } = render(
@@ -655,7 +644,6 @@ describe('AsciinemaPlayer Component', () => {
       const mockCreate = jest.fn();
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // With poster but no startAt.
       const { rerender, container } = render(
         <AsciinemaPlayer src="/fixtures/test-cast.json" poster="npt:1:00" />
       );
@@ -679,7 +667,6 @@ describe('AsciinemaPlayer Component', () => {
 
       jest.clearAllMocks();
 
-      // With startAt but no poster.
       rerender(<AsciinemaPlayer src="/fixtures/test-cast.json" startAt={30} />);
 
       await new Promise(resolve => setTimeout(resolve, 50));
@@ -703,7 +690,6 @@ describe('AsciinemaPlayer Component', () => {
     test('handles errors during library loading', async () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
-      // Force an error by making querySelector throw.
       const originalQuerySelector = document.querySelector;
       document.querySelector = jest.fn().mockImplementation(() => {
         throw new Error('Mock error');
@@ -715,16 +701,13 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Should still render the container.
       expect(container.firstChild).toBeInTheDocument();
 
-      // Should log the error.
       expect(consoleSpy).toHaveBeenCalledWith(
         'Failed to load Asciinema player:',
         expect.any(Error)
       );
 
-      // Restore.
       document.querySelector = originalQuerySelector;
       consoleSpy.mockRestore();
     });
@@ -737,16 +720,13 @@ describe('AsciinemaPlayer Component', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      // Find the script and simulate its onload (library not yet available).
       const script = document.head.querySelector(
         'script[src*="asciinema-player.min.js"]'
       );
       expect(script).toBeInTheDocument();
 
-      // Mock the library being available after script loads.
       window.AsciinemaPlayer = { create: mockCreate };
 
-      // Trigger the onload handler to cover the startAt assignment.
       if (script.onload) {
         script.onload();
       }

--- a/init.sh
+++ b/init.sh
@@ -138,6 +138,13 @@ convert_string() {
   esac
 }
 
+to_lowercase() {
+  echo "${1}" | tr '[:upper:]' '[:lower:]'
+}
+
+# Convert to PascalCase for project names (brief one-liner)
+to_pascalcase() { echo "${1}" | awk -F'[-_ ]' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); } 1' OFS=''; }
+
 #-------------------------------------------------------------------------------
 # FILE OPERATION FUNCTIONS
 #-------------------------------------------------------------------------------
@@ -158,13 +165,6 @@ replace_string_content() {
   grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${needle}" "$(pwd)" | xargs sed "${sed_opts[@]}" "s!${needle}!${replacement}!g" || true
   set -e
 }
-
-to_lowercase() {
-  echo "${1}" | tr '[:upper:]' '[:lower:]'
-}
-
-# Convert to PascalCase for project names (brief one-liner)
-to_pascalcase() { echo "${1}" | awk -F'[-_ ]' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); } 1' OFS=''; }
 
 remove_string_content() {
   local token="${1}"
@@ -346,6 +346,16 @@ validate_author() {
     echo "Error: Author name cannot be empty" >&2
     return 1
   }
+}
+
+##
+# Ensure the PHP sub-mode selection is not contradictory.
+#
+validate_php_mode() {
+  if [ "${use_php_command}" = "y" ] && [ "${use_php_script}" = "y" ]; then
+    echo "Error: --php-command and --php-script cannot be used together." >&2
+    return 1
+  fi
 }
 
 #-------------------------------------------------------------------------------
@@ -900,16 +910,6 @@ parse_args() {
   done
 
   validate_php_mode || exit 1
-}
-
-##
-# Ensure the PHP sub-mode selection is not contradictory.
-#
-validate_php_mode() {
-  if [ "${use_php_command}" = "y" ] && [ "${use_php_script}" = "y" ]; then
-    echo "Error: --php-command and --php-script cannot be used together." >&2
-    return 1
-  fi
 }
 
 #-------------------------------------------------------------------------------

--- a/init.sh
+++ b/init.sh
@@ -109,8 +109,8 @@ interactive=1
 # @return string Converted string
 #
 convert_string() {
-  input_string="$1"
-  conversion_type="$2"
+  local input_string="${1}"
+  local conversion_type="${2}"
 
   case "${conversion_type}" in
     "file_name" | "route_path" | "deployment_id")
@@ -155,7 +155,7 @@ replace_string_content() {
   local sed_opts
   sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
   set +e
-  grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${needle}" "$(pwd)" | xargs sed "${sed_opts[@]}" "s!$needle!$replacement!g" || true
+  grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${needle}" "$(pwd)" | xargs sed "${sed_opts[@]}" "s!${needle}!${replacement}!g" || true
   set -e
 }
 
@@ -227,29 +227,29 @@ remove_special_comments() {
 # @return string User input or default value
 #
 ask() {
-  local label="$1"
-  local prompt="$1"
+  local label="${1}"
+  local prompt="${1}"
   local default="${2-}"
   local result=""
 
-  if [[ -n $default ]]; then
+  if [ -n "${default}" ]; then
     prompt="${prompt} [${default}]: "
   else
     prompt="${prompt}: "
   fi
 
-  while [[ -z ${result} ]]; do
+  while [ -z "${result}" ]; do
     if ! read -p "${prompt}" result; then
       # Stdin reached EOF with no value. This happens when the script is piped
       # (e.g. 'curl ... | bash') without options, so there is nothing to read.
-      if [[ -n $default ]]; then
+      if [ -n "${default}" ]; then
         result="${default}"
         break
       fi
       echo "Error: No input available for '${label}'. Pass options (run with --help) or run interactively." >&2
       exit 1
     fi
-    if [[ -n $default && -z ${result} ]]; then
+    if [ -n "${default}" ] && [ -z "${result}" ]; then
       result="${default}"
     fi
   done
@@ -269,7 +269,7 @@ ask_yesno() {
   local result
 
   read -p "${prompt} [$([ "${default}" = "Y" ] && echo "Y/n" || echo "y/N")]: " result
-  result="$(echo "${result:-${default}}" | tr '[:upper:]' '[:lower:]')"
+  result="$(to_lowercase "${result:-${default}}")"
   echo "${result}"
 }
 
@@ -294,14 +294,14 @@ ask_choice() {
     if ! read -p "${label} (${choices}) [${default}]: " result; then
       # Stdin reached EOF with no value. This happens when the script is piped
       # (e.g. 'curl ... | bash') without options, so there is nothing to read.
-      if [[ -n ${default} ]]; then
+      if [ -n "${default}" ]; then
         result="${default}"
         break
       fi
       echo "Error: No input available for '${label}'. Pass options (run with --help) or run interactively." >&2
       exit 1
     fi
-    result="$(echo "${result:-${default}}" | tr '[:upper:]' '[:lower:]')"
+    result="$(to_lowercase "${result:-${default}}")"
     [[ ${result} != *" "* ]] && [[ " ${options} " == *" ${result} "* ]] && break
   done
 
@@ -357,9 +357,9 @@ remove_php() {
   remove_php_command_build
   remove_php_script
 
-  rm -f composer.json >/dev/null || true
-  rm -f composer.lock >/dev/null || true
-  rm -Rf vendor >/dev/null || true
+  rm -f composer.json || true
+  rm -f composer.lock || true
+  rm -Rf vendor || true
   rm -Rf tests/phpunit || true
   rm -f phpcs.xml || true
   rm -f phpstan.neon || true
@@ -396,11 +396,11 @@ remove_php() {
 }
 
 remove_php_command() {
-  rm -Rf php-command || true
+  rm -f php-command || true
   rm -Rf src || true
-  rm -Rf tests/phpunit/Functional/ApplicationFunctionalTestCase.php || true
-  rm -Rf tests/phpunit/Functional/JokeCommandTest.php || true
-  rm -Rf tests/phpunit/Functional/SayHelloCommandTest.php || true
+  rm -f tests/phpunit/Functional/ApplicationFunctionalTestCase.php || true
+  rm -f tests/phpunit/Functional/JokeCommandTest.php || true
+  rm -f tests/phpunit/Functional/SayHelloCommandTest.php || true
   rm -f docs/content/php/php-command.mdx || true
 
   remove_tokens_with_content "PHP_COMMAND"
@@ -410,8 +410,8 @@ remove_php_command() {
 }
 
 remove_php_command_build() {
-  rm -Rf box.json || true
-  rm -Rf docs/content/ci/php-packaging.mdx || true
+  rm -f box.json || true
+  rm -f docs/content/ci/php-packaging.mdx || true
   remove_tokens_with_content "PHP_PHAR"
 }
 
@@ -420,7 +420,6 @@ remove_php_script() {
   rm -f php-script || true
   rm -f tests/phpunit/Unit/ExampleScriptUnitTest.php || true
   rm -f tests/phpunit/Unit/ScriptUnitTestCase.php || true
-  rm -f tests/phpunit/Unit/ExampleScriptUnitTest.php || true
   rm -f tests/phpunit/Functional/ScriptFunctionalTestCase.php || true
   rm -f tests/phpunit/Functional/ExampleScriptFunctionalTest.php || true
   remove_tokens_with_content "!PHP_COMMAND"
@@ -431,15 +430,15 @@ remove_php_script() {
 }
 
 remove_nodejs() {
-  rm -f package.json >/dev/null || true
-  rm -f package-lock.json >/dev/null || true
-  rm -f yarn.lock >/dev/null || true
-  rm -Rf node_modules >/dev/null || true
+  rm -f package.json || true
+  rm -f package-lock.json || true
+  rm -f yarn.lock || true
+  rm -Rf node_modules || true
 
-  rm -f nodejs-script >/dev/null || true
-  rm -f eslint.config.js >/dev/null || true
-  rm -f .c8rc.json >/dev/null || true
-  rm -Rf tests/nodejs >/dev/null || true
+  rm -f nodejs-script || true
+  rm -f eslint.config.js || true
+  rm -f .c8rc.json || true
+  rm -Rf tests/nodejs || true
 
   remove_string_content_line "\/.npmignore" ".gitattributes"
 
@@ -465,7 +464,7 @@ remove_nodejs() {
 }
 
 remove_shell() {
-  rm -f shell-command.sh >/dev/null || true
+  rm -f shell-command.sh || true
   rm -Rf tests/bats || true
 
   rm -f .github/workflows/test-shell.yml || true
@@ -474,8 +473,8 @@ remove_shell() {
 }
 
 remove_docker() {
-  rm -f Dockerfile >/dev/null || true
-  rm -f entrypoint.sh >/dev/null || true
+  rm -f Dockerfile || true
+  rm -f entrypoint.sh || true
 
   rm -f .github/workflows/test-docker.yml || true
   rm -f .github/workflows/release-docker.yml || true
@@ -485,7 +484,7 @@ remove_docker() {
 
 remove_release_drafter() {
   rm -f .github/workflows/draft-release-notes.yml || true
-  rm -f .github/release-drafter.yml
+  rm -f .github/release-drafter.yml || true
   remove_tokens_with_content "RELEASEDRAFTER"
 }
 
@@ -506,7 +505,7 @@ remove_renovate() {
   remove_tokens_with_content "RENOVATE"
 }
 
-cleanup_renovate_managers() {
+remove_renovate_managers() {
   if [ -f renovate.json ] && grep -q '"matchManagers": \[\]' renovate.json; then
     local sed_opts
     sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
@@ -611,17 +610,19 @@ process_claude_settings() {
 }
 
 process_readme() {
+  local project="${1}"
+
   mv README.dist.md "README.md" >/dev/null 2>&1 || true
 
   # Update placeholder image URL and alt text in README.md
-  replace_string_content 'text=Yourproject' "text=${1// /+}"
-  replace_string_content 'alt="Yourproject logo"' "alt=\"${1} logo\""
+  replace_string_content 'text=Yourproject' "text=${project// /+}"
+  replace_string_content 'alt="Yourproject logo"' "alt=\"${project} logo\""
 
-  curl "https://placehold.jp/000000/ffffff/200x200.png?text=${1// /+}&css=%7B%22border-radius%22%3A%22%20100px%22%7D" >logo.tmp.png || true
+  curl "https://placehold.jp/000000/ffffff/200x200.png?text=${project// /+}&css=%7B%22border-radius%22%3A%22%20100px%22%7D" >logo.tmp.png || true
   if [ -s "logo.tmp.png" ]; then
     mv logo.tmp.png "logo.png" >/dev/null 2>&1 || true
   fi
-  rm logo.tmp.png >/dev/null 2>&1 || true
+  rm -f logo.tmp.png || true
 }
 
 ##
@@ -666,10 +667,10 @@ process_internal() {
 
   namespace_lowercase="$(to_lowercase "${namespace}")"
 
-  rm -f SECURITY.md >/dev/null || true
-  rm -Rf ".scaffold" >/dev/null || true
-  rm -f ".github/workflows/scaffold-test.yml" >/dev/null || true
-  rm -f ".github/workflows/scaffold-release-docs.yml" >/dev/null || true
+  rm -f SECURITY.md || true
+  rm -Rf ".scaffold" || true
+  rm -f ".github/workflows/scaffold-test.yml" || true
+  rm -f ".github/workflows/scaffold-release-docs.yml" || true
 
   # The scaffold-only release workflow is always removed, so drop its companion
   # zizmor suppression entry too. Guarded because zizmor.yml is absent when
@@ -898,7 +899,7 @@ parse_args() {
     shift
   done
 
-  validate_php_mode
+  validate_php_mode || exit 1
 }
 
 ##
@@ -907,7 +908,7 @@ parse_args() {
 validate_php_mode() {
   if [ "${use_php_command}" = "y" ] && [ "${use_php_script}" = "y" ]; then
     echo "Error: --php-command and --php-script cannot be used together." >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -1194,18 +1195,18 @@ fetch_and_stage_template() {
   local url="${1}"
   local staging=".scaffold-bootstrap"
 
-  rm -rf "${staging}"
+  rm -Rf "${staging}"
   mkdir -p "${staging}"
 
   if ! curl -fsSL "${url}" -o "${staging}/scaffold.tar.gz"; then
     echo "Error: failed to download the template archive from ${url}." >&2
-    rm -rf "${staging}"
+    rm -Rf "${staging}"
     return 1
   fi
 
   if ! tar -xzf "${staging}/scaffold.tar.gz" -C "${staging}" --strip-components=1; then
     echo "Error: failed to extract the template archive." >&2
-    rm -rf "${staging}"
+    rm -Rf "${staging}"
     return 1
   fi
 
@@ -1213,7 +1214,7 @@ fetch_and_stage_template() {
 
   if [ ! -d "${staging}/.scaffold" ]; then
     echo "Error: the downloaded archive is not a Scaffold template." >&2
-    rm -rf "${staging}"
+    rm -Rf "${staging}"
     return 1
   fi
 
@@ -1224,7 +1225,7 @@ fetch_and_stage_template() {
     [ -e "${entry}" ] || continue
     mv "${entry}" .
   done
-  rm -rf "${staging}"
+  rm -Rf "${staging}"
 }
 
 ##
@@ -1288,7 +1289,7 @@ process_project() {
       mv "php-command" "${php_command_name}" >/dev/null 2>&1 || true
       remove_php_script "${php_command_name}"
     else
-      remove_php_command "${php_command_name}"
+      remove_php_command
       remove_php_command_build
 
       if [ "${use_php_script:-n}" = "y" ]; then
@@ -1331,7 +1332,7 @@ process_project() {
 
   process_claude_settings
 
-  cleanup_renovate_managers
+  remove_renovate_managers
 
   process_readme "${project}"
 

--- a/init.sh
+++ b/init.sh
@@ -142,7 +142,6 @@ to_lowercase() {
   echo "${1}" | tr '[:upper:]' '[:lower:]'
 }
 
-# Convert to PascalCase for project names (brief one-liner)
 to_pascalcase() { echo "${1}" | awk -F'[-_ ]' '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); } 1' OFS=''; }
 
 #-------------------------------------------------------------------------------
@@ -312,8 +311,6 @@ ask_choice() {
 # INPUT VALIDATION FUNCTIONS
 #-------------------------------------------------------------------------------
 
-##
-# Check if required commands are available.
 check_dependencies() {
   local missing=() required=("sed" "grep" "tr" "awk" "curl")
   for cmd in "${required[@]}"; do command -v "${cmd}" >/dev/null 2>&1 || missing+=("${cmd}"); done
@@ -321,8 +318,6 @@ check_dependencies() {
   return 0
 }
 
-##
-# Validate namespace format (PascalCase).
 validate_namespace() {
   [[ ${1} =~ ^[A-Z][a-zA-Z0-9]*$ ]] || {
     echo "Error: Namespace must be PascalCase (e.g., MyNamespace)" >&2
@@ -330,8 +325,6 @@ validate_namespace() {
   }
 }
 
-##
-# Validate project name format (lowercase with hyphens).
 validate_project_name() {
   [[ ${1} =~ ^[a-z0-9-]+$ ]] && [[ ! ${1} =~ ^- ]] && [[ ! ${1} =~ -$ ]] || {
     echo "Error: Project name must be lowercase with hyphens (e.g., my-project)" >&2
@@ -339,8 +332,6 @@ validate_project_name() {
   }
 }
 
-##
-# Validate author name (non-empty).
 validate_author() {
   [ -n "${1}" ] || {
     echo "Error: Author name cannot be empty" >&2
@@ -348,9 +339,6 @@ validate_author() {
   }
 }
 
-##
-# Ensure the PHP sub-mode selection is not contradictory.
-#
 validate_php_mode() {
   if [ "${use_php_command}" = "y" ] && [ "${use_php_script}" = "y" ]; then
     echo "Error: --php-command and --php-script cannot be used together." >&2
@@ -649,9 +637,9 @@ process_contributing() {
 # Replace the self-update skill references with placeholder tokens.
 #
 # The initialised project must keep instructions that point at the upstream
-# template repository rather than at the project's own namespace, so these
-# references are hidden behind tokens before the bulk replacements run and put
-# back afterwards by restore_skill_references().
+# template repository rather than at the project's own namespace. These
+# references are hidden behind tokens before the bulk replacements run and
+# put back afterwards by restore_skill_references().
 #
 protect_skill_references() {
   replace_string_content "https://raw.githubusercontent.com/AlexSkrypnyk/scaffold/main/.scaffold/skills/update-consumer-scaffold/SKILL.md" "__SCAFFOLD_SKILL_URL__"
@@ -691,8 +679,8 @@ process_internal() {
 
   protect_skill_references
 
-  # Replace any existing necessary placeholders using a real value with
-  # tokens used in further replacements.
+  # Replace the real repository name with the placeholder token used in the
+  # replacements below.
   replace_string_content "AlexSkrypnyk/scaffold" "yournamespace/yourproject"
 
   replace_string_content "YourNamespace" "${namespace}"
@@ -739,9 +727,6 @@ process_internal() {
 # ARGUMENT PARSING
 #-------------------------------------------------------------------------------
 
-##
-# Print usage information.
-#
 usage() {
   cat <<'USAGE'
 Usage: ./init.sh [OPTIONS]
@@ -916,9 +901,6 @@ parse_args() {
 # INPUT COLLECTION
 #-------------------------------------------------------------------------------
 
-##
-# Ensure required identity values are present in non-interactive mode.
-#
 require_identity() {
   local missing=()
   [ -z "${namespace}" ] && missing+=("--namespace")
@@ -1005,9 +987,6 @@ apply_noninteractive_defaults() {
   return 0
 }
 
-##
-# Print the selected configuration.
-#
 print_summary() {
   echo
   echo "            Summary"
@@ -1040,9 +1019,6 @@ print_summary() {
   echo
 }
 
-##
-# Collect configuration through interactive prompts.
-#
 collect_interactive() {
   echo "Please follow the prompts to adjust your project configuration"
   echo
@@ -1114,9 +1090,6 @@ collect_interactive() {
   fi
 }
 
-##
-# Collect configuration from options, falling back to defaults.
-#
 collect_noninteractive() {
   require_identity
 
@@ -1151,10 +1124,10 @@ dir_is_empty() {
 ##
 # Resolve the URL of the template archive to download.
 #
-# Precedence: an explicit SCAFFOLD_ARCHIVE_URL wins (an exact archive URL, also
-# the seam tests use to inject a local file); then --ref pins to a tag, branch,
-# or commit; otherwise the latest published release is used, falling back to the
-# default branch when the repository has no releases.
+# Precedence: an explicit SCAFFOLD_ARCHIVE_URL wins (an exact archive URL);
+# then --ref pins to a tag, branch, or commit; otherwise the latest published
+# release is used, falling back to the default branch when the repository has
+# no releases.
 #
 # @return string Archive URL.
 #
@@ -1184,7 +1157,7 @@ resolve_archive_url() {
 # Download, extract, validate, and promote the template into the current dir.
 #
 # The archive is staged in a sub-directory and only promoted once it is
-# confirmed to contain '.scaffold', so a failed download, a partial extraction,
+# confirmed to contain '.scaffold'. A failed download, a partial extraction,
 # or an archive that is not a Scaffold leaves the current directory clean
 # instead of tripping the empty-directory guard on the next attempt.
 #
@@ -1340,10 +1313,10 @@ process_project() {
 
   process_internal "${namespace}" "${project}" "${author}" "${project_pascalcase}"
 
-  # Remove this init script. "${BASH_SOURCE[0]}" is the script's own path when
-  # run as a file, and is empty (or a bare shell name) when piped through
-  # 'curl ... | bash', so only a real on-disk script is removed - never the
-  # interpreter (e.g. "/bin/bash" when invoked as 'curl ... | /bin/bash -s').
+  # "${BASH_SOURCE[0]}" is the script's own path when run as a file, and is
+  # empty (or a bare shell name) when piped through 'curl ... | bash'. Only a
+  # real on-disk script is removed - never the interpreter (e.g. "/bin/bash"
+  # when invoked as 'curl ... | /bin/bash -s').
   local script_path="${BASH_SOURCE[0]:-}"
   if [ "${remove_self}" != "n" ] && [ -n "${script_path}" ] && [ -f "${script_path}" ]; then
     rm -- "${script_path}" || true
@@ -1373,14 +1346,15 @@ main() {
   process_project
 }
 
-# Run main only when the script is executed, not when it is sourced (e.g. by
-# the BATS unit tests). When piped through 'bash -s' the script has no source
-# file, so "${BASH_SOURCE[0]}" is empty - that case must still run.
+# Run main only when the script is executed, not when it is sourced. When
+# piped through 'bash -s' the script has no source file, so
+# "${BASH_SOURCE[0]}" is empty - that case must still run.
 #
 # main is the final statement, which also bounds the effect of a truncated
-# 'curl ... | bash' download: every file and network operation lives inside a
-# function that only main invokes, so a cut-off download performs no real work -
-# at most the harmless top-level variable and option setup before it hits EOF.
+# 'curl ... | bash' download. Every file and network operation lives inside a
+# function that only main invokes, so a cut-off download performs no real
+# work - at most the harmless top-level variable and option setup before it
+# hits EOF.
 if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   main "$@"
 fi

--- a/nodejs-script
+++ b/nodejs-script
@@ -9,12 +9,12 @@
  * external packages.
  *
  * To adopt script template:
- * - Replace "NodeJS CLI script template" with your script human name.
- * - Replace "nodejs-script" with your script file name.
- * - Update arguments count check to suit your needs.
- * - Update printHelp() function with your content.
- * - Copy '/tests/nodejs' directory into your project and update
- *   script.test.js to a script file name.
+ * - Replace "NodeJS CLI script template" with the script's human name.
+ * - Replace "nodejs-script" with the script's file name.
+ * - Update the argument count check as needed.
+ * - Update the printHelp() content.
+ * - Copy '/tests/nodejs' directory into the project and update
+ *   script.test.js to the script's file name.
  * - Remove this block of comments.
  * -----------------------------------------------------------------------------
  *
@@ -59,7 +59,7 @@ function main(argv, argc) {
     throw new Error('Please provide a value of the first argument.');
   }
 
-  // Add your logic here.
+  // Add the script logic here.
   verbose(`Would execute script business logic with argument ${argv[1]}.`);
 }
 
@@ -96,8 +96,8 @@ Examples:
 function verbose(string) {
   buffer.push(string);
 
-  // Treat an unset or '0' value as "not quiet", mirroring a loose emptiness
-  // check, so that only an explicit non-'0' value suppresses the output.
+  // Treat an unset or '0' value as not quiet, so only an explicit non-'0'
+  // value suppresses the output.
   const quiet = process.env.SCRIPT_QUIET;
   if (!quiet || quiet === '0') {
     /* c8 ignore next */
@@ -107,15 +107,13 @@ function verbose(string) {
   return buffer;
 }
 
-// Entrypoint.
-//
 /* c8 ignore start */
 if (require.main === module && process.env.SCRIPT_RUN_SKIP !== '1') {
   try {
     // Drop the Node executable and keep the script path as the first element,
     // so that argv[1] is the first user-provided argument.
     const argv = process.argv.slice(1);
-    // The function should not provide an exit code but rather throw errors.
+    // main() throws on error instead of returning an exit code.
     main(argv, argv.length);
   } catch (error) {
     verbose(`\nERROR: ${error.message}\n`);

--- a/php-script
+++ b/php-script
@@ -111,7 +111,6 @@ if (PHP_SAPI != 'cli' || !empty($_SERVER['REMOTE_ADDR'])) {
   die('This script can be only ran from the command line.');
 }
 
-// Allow to skip the script run.
 if (getenv('SCRIPT_RUN_SKIP') != 1) {
   set_error_handler(function (int $severity, string $message, string $file, int $line): bool {
     if (!(error_reporting() & $severity)) {
@@ -125,7 +124,7 @@ if (getenv('SCRIPT_RUN_SKIP') != 1) {
   try {
     $argv = is_array($_SERVER['argv'] ?? NULL) ? array_filter($_SERVER['argv'], 'is_string') : [];
     $argc = is_scalar($_SERVER['argc'] ?? NULL) ? (int) $_SERVER['argc'] : 0;
-    // The function should not provide an exit code but rather throw exceptions.
+    // main() throws exceptions instead of returning an exit code.
     main($argv, $argc);
   }
   catch (\ErrorException $exception) {

--- a/shell-command.sh
+++ b/shell-command.sh
@@ -13,10 +13,8 @@
 set -euo pipefail
 [ "${SCRIPT_DEBUG-}" = "1" ] && set -x
 
-# URL endpoint to fetch the data from.
 URL_ENDPOINT="${JOKE_URL_ENDPOINT:-https://official-joke-api.appspot.com/jokes/__TOPIC__/random}"
 
-# Topic.
 topic="${1-}"
 
 # Flag to bypass the prompt to proceed.
@@ -87,9 +85,7 @@ main() {
   echo
 
   response="$(curl -sL "${url}")"
-  # Extract 'setup'
   setup=$(echo "${response}" | sed -E 's/.*"setup":"([^"]+)".*/\1/')
-  # Extract 'punchline'
   punchline=$(echo "${response}" | sed -E 's/.*"punchline":"([^"]+)".*/\1/')
 
   echo "$setup"

--- a/src/Command/JokeCommand.php
+++ b/src/Command/JokeCommand.php
@@ -12,9 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Joke command.
  *
- * Allows to get a random joke.
- *
- * @package YourNamespace\App\Command
+ * Retrieves a random joke.
  */
 class JokeCommand extends Command {
 

--- a/src/Command/SayHelloCommand.php
+++ b/src/Command/SayHelloCommand.php
@@ -10,10 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Say hello command.
- *
- * Allows to say hello.
- *
- * @package YourNamespace\App\Command
  */
 class SayHelloCommand extends Command {
 

--- a/tests/bats/_helper.bash
+++ b/tests/bats/_helper.bash
@@ -12,34 +12,28 @@
 setup() {
   [ ! -d ".git" ] && echo "Tests must be run from the repository root directory." && exit 1
 
-  # For a list of available variables see:
+  # Available BATS variables:
   # @see https://bats-core.readthedocs.io/en/stable/writing-tests.html#special-variables
 
-  # Register a path to libraries.
   export BATS_LIB_PATH="${BATS_TEST_DIRNAME}/node_modules"
 
-  # Load 'bats-helpers' library.
   bats_load_library bats-helpers
 
-  # Setup command mocking.
   mock_setup
 
-  # Current directory where the test is run from.
   # shellcheck disable=SC2155
   export CUR_DIR="$(pwd)"
 
   # Project directory root (where .git is located).
   export ROOT_DIR="${CUR_DIR}"
 
-  # Directory where the shell command script will be running in.
+  # Directory where the shell command script runs.
   export BUILD_DIR="${BUILD_DIR:-"${BATS_TEST_TMPDIR//\/\//\/}/shell-$(date +%s)"}"
   fixture_prepare_dir "${BUILD_DIR}"
 
-  # Copy codebase at the last commit into the BUILD_DIR.
-  # Tests requiring to work with the copy of the codebase should opt-in using
-  # BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
-  # Note that during development of tests the local changes need to be
-  # committed.
+  # Copy the codebase at the last commit into BUILD_DIR. Tests that work with
+  # the copy opt in with BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1.
+  # During test development, local changes must be committed.
   fixture_export_codebase "${BUILD_DIR}" "${ROOT_DIR}"
 
   # Print debug information if "--verbose-run" is passed.
@@ -56,6 +50,5 @@ setup() {
 }
 
 teardown() {
-  # Move back to the original directory.
   popd >/dev/null || cd "${CUR_DIR}" || exit 1
 }

--- a/tests/phpunit/Functional/ExampleScriptFunctionalTest.php
+++ b/tests/phpunit/Functional/ExampleScriptFunctionalTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
- * Class ExampleScriptFunctionalTest.
- *
  * Functional tests for php-script.
  */
 #[CoversFunction('main')]

--- a/tests/phpunit/Functional/JokeCommandTest.php
+++ b/tests/phpunit/Functional/JokeCommandTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use YourNamespace\App\Command\JokeCommand;
 
 /**
- * Unit test for the JokeCommand class.
+ * Functional test for the JokeCommand class.
  */
 #[CoversMethod(JokeCommand::class, 'execute')]
 #[CoversMethod(JokeCommand::class, 'configure')]

--- a/tests/phpunit/Functional/JokeCommandTest.php
+++ b/tests/phpunit/Functional/JokeCommandTest.php
@@ -13,9 +13,7 @@ use PHPUnit\Framework\TestCase;
 use YourNamespace\App\Command\JokeCommand;
 
 /**
- * Class JokeCommandTest.
- *
- * This is a unit test for the JokeCommand class.
+ * Unit test for the JokeCommand class.
  */
 #[CoversMethod(JokeCommand::class, 'execute')]
 #[CoversMethod(JokeCommand::class, 'configure')]

--- a/tests/phpunit/Functional/SayHelloCommandTest.php
+++ b/tests/phpunit/Functional/SayHelloCommandTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use YourNamespace\App\Command\SayHelloCommand;
 
 /**
- * Unit test for the SayHelloCommand class.
+ * Functional test for the SayHelloCommand class.
  */
 #[CoversMethod(SayHelloCommand::class, 'execute')]
 #[CoversMethod(SayHelloCommand::class, 'configure')]

--- a/tests/phpunit/Functional/SayHelloCommandTest.php
+++ b/tests/phpunit/Functional/SayHelloCommandTest.php
@@ -12,9 +12,7 @@ use PHPUnit\Framework\TestCase;
 use YourNamespace\App\Command\SayHelloCommand;
 
 /**
- * Class SayHelloCommandTest.
- *
- * This is a unit test for the SayHelloCommand class.
+ * Unit test for the SayHelloCommand class.
  */
 #[CoversMethod(SayHelloCommand::class, 'execute')]
 #[CoversMethod(SayHelloCommand::class, 'configure')]

--- a/tests/phpunit/Functional/ScriptFunctionalTestCase.php
+++ b/tests/phpunit/Functional/ScriptFunctionalTestCase.php
@@ -7,8 +7,6 @@ namespace YourNamespace\App\Tests\Functional;
 use YourNamespace\App\Tests\Unit\ScriptUnitTestCase;
 
 /**
- * Class ScriptFunctionalTestCase.
- *
  * Base class to functional test scripts.
  */
 abstract class ScriptFunctionalTestCase extends ScriptUnitTestCase {
@@ -29,9 +27,7 @@ abstract class ScriptFunctionalTestCase extends ScriptUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    // Allow script to run.
     putenv('SCRIPT_RUN_SKIP=0');
-    // Log output into stdout.
     putenv('SCRIPT_QUIET=0');
   }
 

--- a/tests/phpunit/Unit/ExampleScriptUnitTest.php
+++ b/tests/phpunit/Unit/ExampleScriptUnitTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Class ExampleScriptUnitTest.
- *
  * Unit tests for php-script.
  */
 #[CoversFunction('main')]

--- a/tests/phpunit/Unit/ScriptUnitTestCase.php
+++ b/tests/phpunit/Unit/ScriptUnitTestCase.php
@@ -8,8 +8,6 @@ use AlexSkrypnyk\PhpunitHelpers\Traits\AssertArrayTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class ScriptUnitTestCase.
- *
  * Base class to unit test scripts.
  */
 abstract class ScriptUnitTestCase extends TestCase {
@@ -27,9 +25,8 @@ abstract class ScriptUnitTestCase extends TestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    // Prevent script from running.
     putenv('SCRIPT_RUN_SKIP=1');
-    // Log output into internal buffer instead of stdout so we can assert it.
+    // Log output into internal buffer instead of stdout so tests can assert it.
     putenv('SCRIPT_QUIET=1');
 
     if (!is_readable(static::$script)) {


### PR DESCRIPTION
## Summary

This is a consistency-convergence pass over the Scaffold template: behavior-preserving edits that make the codebase internally consistent with itself, with no feature change and no intentional behavior change.
It converges naming (`cleanup_renovate_managers` -> `remove_renovate_managers`, `cleanupFile` -> `removeFile`, `dataProviderClaudeSettings` -> `dataProviderInitClaudeSettings`), shell conventions in `init.sh` and its BATS suite, the structural placement of helpers and data providers, and the comment register across the first-party source.
One small, genuine bug fix rides along in `InitTest::testInitTestActionsPassesZizmor`.
The snapshot fixtures under `.scaffold/tests/phpunit/fixtures/` were regenerated with `composer update-snapshots` because they are full copies of the generated project tree and the comment pass left them stale; that churn is derived output, not hand-written change.

## Changes

### Naming

- Renamed `cleanup_renovate_managers` to `remove_renovate_managers` in `init.sh`, joining the 21-strong `remove_` family, and updated its references in `.scaffold/tests/bats/init.bats`.
- Renamed `cleanupFile` to `removeFile` in `.scaffold/assets/update-assets.php` to match its sibling `removeDir` and its own docblock verb.
- Renamed `dataProviderClaudeSettings` to `dataProviderInitClaudeSettings` in `.scaffold/tests/phpunit/src/InitTest.php` to mirror its full test name, matching the two sibling providers.

### Shell conventions in `init.sh`

- Braced positional parameter expansions (`$1` -> `${1}`) throughout, added missing `local` declarations in `convert_string`, and named the `project` positional in `process_readme`.
- Converted five plain `-n`/`-z` `[[ ]]` tests to quoted `[ ]` tests, keeping `[[ ]]` where regex or glob matching is required.
- Reused the existing `to_lowercase` helper in `ask_yesno` and `ask_choice` instead of inlining its `tr` pipeline twice.
- Normalized `rm` idioms (`-f` for files, `-Rf` for directories), dropped a redundant `>/dev/null` on 18 lines, removed one duplicated removal line in `remove_php_script`, and added a missing `|| true` guard to `remove_release_drafter`.
- Made `validate_php_mode` return 1 like its three sibling validators, with `|| exit 1` added at the call site in `parse_args`.
- Dropped an argument from a `remove_php_command` call that the function never read.

### Structure

- Moved `to_lowercase`/`to_pascalcase` under the `STRING UTILITIES` section in `init.sh`, next to `convert_string`.
- Moved `validate_php_mode` in with its `validate_` siblings under `INPUT VALIDATION FUNCTIONS`, ahead of its first caller.
- Regrouped the `parse_args --ref` BATS test with the other `parse_args` tests in `.scaffold/tests/bats/init.bats`.
- Moved the two clustered `InitTest` data providers (`dataProviderInit`, `dataProviderInitNonInteractive`) to sit directly after the tests they feed.

### Bug fix

- In `testInitTestActionsPassesZizmor`, the `self::$fixtures = NULL` sentinel now runs before `markTestSkipped()` instead of after, so a skipped run (zizmor binary unavailable) no longer leaves a stale static fixture path for `tearDown()` to act on.

### BATS suite conventions

- Aligned test names on the suite's SUT-first, active-verb grammar (for example, "Test all conversions" became "convert_string converts to each conversion type").
- Standardized temp-dir slugs on snake_case (for example `tpl-src` became `template_src`).
- Used `assert_output` for exact output matching instead of `assert_equal "${output}" ...`.
- Used `|| return 1` guards after `pushd`/`popd` instead of `|| exit 1`.
- Declared one previously-undeclared test-local variable with `local`.

### Comment register

- Ran a comment-register pass over the full first-party source: deleted 76 comments that restated the code, narrated a past change, or asserted a fact owned outside the file; reworded 31 into a declarative present-tense register; left 148 untouched.
- Token markers, coverage pragmas, lint directives, PHPUnit attributes, and linter-required docblocks were out of scope.

### Corrected claims

- `JokeCommandTest` and `SayHelloCommandTest` drive their command through a real Symfony application via `ApplicationTrait` and live under `tests/phpunit/Functional/`, but their docblocks described them as unit tests. Both now read "Functional test for the ... class."
- The comment pass deliberately collected this as a wrong claim instead of silently correcting it, on the principle that a factual fix should not be buried inside a wording diff. It is applied here as its own reviewed change, with the four mirroring fixture copies regenerated from the source.

### Derived output

- Regenerated the snapshot fixtures under `.scaffold/tests/phpunit/fixtures/` with `composer update-snapshots` since they are full copies of the generated project tree and the comment pass left them stale.

## Before / After

```
┌─────────────────────────────────────────────────────────────────────────────────┐
│ CONVERGENCE PASS: BEFORE -> AFTER                                               │
├─────────────────────────────────────────────────────────────────────────────────┤
│ NAMING                                                                          │
│   cleanup_renovate_managers()   ->  remove_renovate_managers()                  │
│   cleanupFile()                 ->  removeFile()                                │
│   dataProviderClaudeSettings()  ->  dataProviderInitClaudeSettings()            │
│                                                                                 │
│ STRUCTURE                                                                       │
│   to_lowercase / to_pascalcase  ->  grouped under STRING UTILITIES              │
│   validate_php_mode             ->  grouped with its validate_ siblings         │
│   InitTest data providers       ->  placed after the tests they feed            │
│   parse_args --ref BATS test    ->  grouped with the other parse_args tests     │
│                                                                                 │
│ SHELL CONVENTIONS (init.sh)                                                     │
│   bare $1 / $2                    ->  braced ${1} / ${2}                        │
│   five bare [[ -n/-z ]] tests     ->  quoted [ ]; [[ ]] kept for regex/glob     │
│   two inlined tr pipelines        ->  reuse of the to_lowercase() helper        │
│   mixed rm idioms/stray guards    ->  rm -f / rm -Rf, consistent || true guards │
│   validate_php_mode: exit 1       ->  return 1, caller adds || exit 1           │
│                                                                                 │
│ BUG FIX                                                                         │
│   zizmor test: fixtures=NULL set AFTER markTestSkipped()                        │
│              -> fixtures=NULL set BEFORE markTestSkipped()                      │
│                                                                                 │
│ COMMENTS (first-party source)                                                   │
│   76 removed (restated code / narration)   31 reworded   148 kept               │
│                                                                                 │
│ CORRECTED CLAIMS                                                                │
│   command test docblocks: "Unit test"  ->  "Functional test"                    │
│                                                                                 │
│ DERIVED OUTPUT                                                                  │
│   .scaffold/tests/phpunit/fixtures/  regenerated via update-snapshots           │
└─────────────────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Standardized naming and structure across shell, BATS, PHP, and PHPUnit code.
- Renamed helpers, data providers, and Renovate cleanup operations.
- Improved argument parsing, quoting, validation, and fixture handling.
- Added `parse_args --ref` coverage and updated related BATS assertions.
- Reorganized tests, helpers, validators, and data providers.
- Removed 76 redundant comments and reworded 31 comments.
- Regenerated snapshot fixtures.
- Fixed zizmor test skip handling by initializing the fixture sentinel before checking the executable.

## Possibly related

- Related issue search was inconclusive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
