### PR TITLE
[#599] Excluded consumer-owned '.claude' files from the 'init.sh' token sweeps.

### DIFF
--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -94,10 +94,14 @@ Content blocks can be conditionally included/excluded using special tokens:
 
 ### Sweep scope and the `.claude` allowlist
 
-Every helper above, plus `remove_tokens_with_content()` and
-`remove_special_comments()`, gets its file list from `sweep_files()`. It searches
-the project root recursively, skipping `.git`, `.idea`, `.claude`, `vendor` and
-`node_modules`, then searches the template-owned `.claude` paths explicitly:
+Five helpers sweep the project for a needle and edit whatever they find:
+`replace_string_content()`, `remove_string_content()`,
+`remove_string_content_line()`, `remove_tokens_with_content()` and
+`remove_special_comments()`. All five get their file list from `sweep_files()`.
+(`uncomment_line()` is not one of them - it edits the single file named in its
+argument.) `sweep_files()` searches the project root recursively, skipping
+`.git`, `.idea`, `.claude`, `vendor` and `node_modules`, then searches the
+template-owned `.claude` paths explicitly:
 
 - `.claude/settings.json`
 - `.claude/skills/update-architecture-docs`

--- a/.scaffold/CLAUDE.md
+++ b/.scaffold/CLAUDE.md
@@ -92,6 +92,32 @@ Content blocks can be conditionally included/excluded using special tokens:
 - `remove_string_content_line()` - Remove lines containing token
 - `uncomment_line()` - Activate commented configuration
 
+### Sweep scope and the `.claude` allowlist
+
+Every helper above, plus `remove_tokens_with_content()` and
+`remove_special_comments()`, gets its file list from `sweep_files()`. It searches
+the project root recursively, skipping `.git`, `.idea`, `.claude`, `vendor` and
+`node_modules`, then searches the template-owned `.claude` paths explicitly:
+
+- `.claude/settings.json`
+- `.claude/skills/update-architecture-docs`
+
+`.claude` needs that split because it is the one directory holding both
+template-owned and consumer-owned files. The `update-consumer-scaffold` skill
+carries the consumer's `.claude` across its clean-the-root step and then extracts
+a fresh template on top, so `init.sh` runs over a merged tree. Sweeping the whole
+of `.claude` rewrites the consumer's own skills, agents and local settings -
+including the fetched copy of the update skill, which then names the consumer's
+repository and makes the next update pull the wrong project. Excluding the whole
+of `.claude` instead strands the `AI_ARCH_DOCS_MERMAID` / `AI_ARCH_DOCS_PLANTUML`
+blocks in the shipped `update-architecture-docs` skill.
+
+**Shipping a new file under `.claude` means adding its path to `sweep_files()`.**
+`testInitProcessesShippedClaudeFiles` fails when a shipped `.claude` file keeps a
+`#;` marker or an unsubstituted placeholder, and
+`testInitPreservesConsumerClaudeFiles` fails when a consumer-owned `.claude` file
+is modified at all.
+
 ## PHP Template Features
 
 ### Dual Implementation Pattern

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -8,6 +8,7 @@ use AlexSkrypnyk\File\File;
 use AlexSkrypnyk\Snapshot\Replacer\Replacer;
 use Laravel\SerializableClosure\SerializableClosure;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\ExecutableFinder;
 
 /**
@@ -659,6 +660,126 @@ final class InitTest extends UnitTestCase {
 
     $this->assertFileDoesNotExist(self::$sut . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'settings.json');
     $this->assertDirectoryDoesNotExist(self::$sut . DIRECTORY_SEPARATOR . '.claude');
+  }
+
+  /**
+   * Consumer-owned files under '.claude' survive an init run byte-for-byte.
+   *
+   * The update flow keeps the consumer's '.claude' across its wipe and then
+   * extracts the template on top, so init.sh runs over a tree holding both
+   * template-owned and consumer-owned files. Sweeping the consumer's agent
+   * configuration rewrote the fetched update skill to name the consumer's own
+   * repository, so a later run would pull the wrong project.
+   *
+   * @param string $path
+   *   Path of the consumer-owned file, relative to '.claude'.
+   */
+  #[DataProvider('dataProviderInitPreservesConsumerClaudeFiles')]
+  public function testInitPreservesConsumerClaudeFiles(string $path): void {
+    self::$fixtures = NULL;
+
+    $claude_dir = self::$sut . DIRECTORY_SEPARATOR . '.claude';
+    $file = $claude_dir . DIRECTORY_SEPARATOR . $path;
+    $planted = self::consumerClaudeContent();
+    File::dump($file, $planted);
+
+    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', [
+      '--namespace=AcmeApp',
+      '--name=acme-app',
+      '--author=Jane Doe',
+      '--php-command-name=acme-cli',
+    ]);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains('Initialization complete.');
+
+    $this->assertSame($planted, (string) file_get_contents($file));
+  }
+
+  public static function dataProviderInitPreservesConsumerClaudeFiles(): \Iterator {
+    // The skill the consumer fetches on demand to run the next update.
+    yield 'update skill' => ['skills/update-consumer-scaffold/SKILL.md'];
+    // Personal Claude Code overrides, git-ignored and never template-owned.
+    yield 'local settings' => ['settings.local.json'];
+    // A skill and an agent the consumer wrote themselves.
+    yield 'consumer skill' => ['skills/acme-deploy/SKILL.md'];
+    yield 'consumer agent' => ['agents/acme-reviewer.md'];
+  }
+
+  /**
+   * Every string init.sh sweeps for, in a consumer-owned file.
+   *
+   * Each line carries a needle from process_internal() or a token marker the
+   * block and comment helpers act on, so any helper that reaches this file
+   * changes it.
+   */
+  protected static function consumerClaudeContent(): string {
+    return implode("\n", [
+      '# Update Scaffold',
+      '',
+      'gh release list --repo AlexSkrypnyk/scaffold --limit 5',
+      'The scaffold template lives at [getscaffold.dev](https://getscaffold.dev).',
+      'Run ./php-command, ./php-script and ./shell-command.sh.',
+      'Namespace YourNamespace in yournamespace/yourproject, titled Yourproject.',
+      'Authored by Your Name, maintained by Alex Skrypnyk.',
+      'Generic project scaffold template',
+      '',
+      '#;< PHP',
+      'A PHP-only note.',
+      '#;> PHP',
+      '#; A bare marker.',
+      '',
+    ]);
+  }
+
+  /**
+   * Template-owned '.claude' files are still processed by the sweep helpers.
+   *
+   * Excluding '.claude' from the sweep must not overshoot: the shipped
+   * 'update-architecture-docs' skill carries the diagram-format token blocks,
+   * so the unselected format must be gone and no raw '#;' marker or
+   * unsubstituted placeholder may survive anywhere under '.claude'.
+   *
+   * @param list<string> $arguments
+   *   Command-line arguments passed to init.sh.
+   * @param string $present
+   *   Heading of the diagram-format section that must survive.
+   * @param string $absent
+   *   Heading of the diagram-format section that must be removed.
+   */
+  #[DataProvider('dataProviderInitProcessesShippedClaudeFiles')]
+  public function testInitProcessesShippedClaudeFiles(array $arguments, string $present, string $absent): void {
+    self::$fixtures = NULL;
+
+    $arguments = array_merge(['--namespace=AcmeApp', '--name=acme-app', '--author=Jane Doe'], $arguments);
+    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', $arguments);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains('Initialization complete.');
+
+    $skill = self::$sut . DIRECTORY_SEPARATOR . '.claude' . DIRECTORY_SEPARATOR . 'skills' . DIRECTORY_SEPARATOR . 'update-architecture-docs' . DIRECTORY_SEPARATOR . 'SKILL.md';
+    $content = (string) file_get_contents($skill);
+    $this->assertStringContainsString($present, $content);
+    $this->assertStringNotContainsString($absent, $content);
+
+    // The allowlist of swept template paths only holds while no other shipped
+    // '.claude' file needs a substitution. Assert it rather than trust it.
+    $finder = (new Finder())->files()->in(self::$sut . DIRECTORY_SEPARATOR . '.claude')->ignoreDotFiles(FALSE);
+    $placeholders = ['#;', 'YourNamespace', 'yournamespace', 'yourproject', 'Yourproject', 'Your Name'];
+
+    foreach ($finder as $file) {
+      foreach ($placeholders as $placeholder) {
+        $this->assertStringNotContainsString($placeholder, $file->getContents(), sprintf('Unprocessed "%s" in shipped .claude file "%s".', $placeholder, $file->getRelativePathname()));
+      }
+    }
+  }
+
+  public static function dataProviderInitProcessesShippedClaudeFiles(): \Iterator {
+    $mermaid = '## Diagram format: Mermaid';
+    $plantuml = '## Diagram format: PlantUML';
+
+    yield 'mermaid by default' => [[], $mermaid, $plantuml];
+    yield 'plantuml when selected' => [['--ai-arch-docs=plantuml'], $plantuml, $mermaid];
   }
 
   protected static function defaultAnswers(): array {

--- a/init.sh
+++ b/init.sh
@@ -149,8 +149,36 @@ to_pascalcase() { echo "${1}" | awk -F'[-_ ]' '{for(i=1;i<=NF;i++) $i=toupper(su
 #-------------------------------------------------------------------------------
 
 ##
+# List the files containing a needle, restricted to template-owned paths.
+#
+# '.claude' is excluded from the recursive search. An update run merges a new
+# template into a tree that already carries the consumer's own agent
+# configuration - skills, agents and local settings this script does not own -
+# and sweeping those rewrites them: the fetched update skill ends up naming the
+# consumer's repository instead of the template's, so the next update pulls the
+# wrong project. The '.claude' paths the template itself ships are searched
+# explicitly, because they still carry tokens that must be processed. Shipping
+# another file under '.claude' means listing it here.
+#
+# @param $1 string Needle (string to find)
+# @param $2 string Path relative to the project root to search instead of the
+#                  whole tree (optional)
+#
+sweep_files() {
+  local needle="${1}"
+  local target="${2:-}"
+
+  if [ -n "${target}" ]; then
+    grep -rIl "${needle}" "$(pwd)/${target}" 2>/dev/null || true
+    return 0
+  fi
+
+  grep -rIl --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir=".claude" --exclude-dir="vendor" --exclude-dir="node_modules" "${needle}" "$(pwd)" || true
+  grep -rIl "${needle}" "$(pwd)/.claude/settings.json" "$(pwd)/.claude/skills/update-architecture-docs" 2>/dev/null || true
+}
+
+##
 # Replace all occurrences of a string in files.
-# Searches recursively, excluding common directories.
 #
 # @param $1 string Needle (string to find)
 # @param $2 string Replacement (string to replace with)
@@ -160,24 +188,22 @@ replace_string_content() {
   local replacement="${2}"
   local sed_opts
   sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
-  set +e
-  grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${needle}" "$(pwd)" | xargs sed "${sed_opts[@]}" "s!${needle}!${replacement}!g" || true
-  set -e
+  sweep_files "${needle}" | xargs sed "${sed_opts[@]}" "s!${needle}!${replacement}!g" || true
 }
 
 remove_string_content() {
   local token="${1}"
   local sed_opts
   sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
-  grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${token}" "$(pwd)" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/^${token}/d" || true
+  sweep_files "${token}" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/^${token}/d" || true
 }
 
 remove_string_content_line() {
   local token="${1}"
-  local target="${2:-.}"
+  local target="${2:-}"
   local sed_opts
   sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
-  grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${token}" "$(pwd)/${target}" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/${token}/d" || true
+  sweep_files "${token}" "${target}" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/${token}/d" || true
 }
 
 ##
@@ -196,7 +222,7 @@ remove_tokens_with_content() {
   local token="${1}"
   local sed_opts
   sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
-  grep -rI --include=".*" --include="*" --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "#;> $token" "$(pwd)" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/#;< $token/,/#;> $token/d" || true
+  sweep_files "#;> $token" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/#;< $token/,/#;> $token/d" || true
 }
 
 uncomment_line() {
@@ -211,7 +237,7 @@ remove_special_comments() {
   local token="#;"
   local sed_opts
   sed_opts=(-i) && [ "$(uname)" = "Darwin" ] && sed_opts=(-i '')
-  grep -rI --exclude-dir=".git" --exclude-dir=".idea" --exclude-dir="vendor" --exclude-dir="node_modules" -l "${token}" "$(pwd)" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/${token}/d" || true
+  sweep_files "${token}" | LC_ALL=C.UTF-8 xargs sed "${sed_opts[@]}" -e "/${token}/d" || true
 }
 
 #-------------------------------------------------------------------------------

--- a/init.sh
+++ b/init.sh
@@ -151,14 +151,9 @@ to_pascalcase() { echo "${1}" | awk -F'[-_ ]' '{for(i=1;i<=NF;i++) $i=toupper(su
 ##
 # List the files containing a needle, restricted to template-owned paths.
 #
-# '.claude' is excluded from the recursive search. An update run merges a new
-# template into a tree that already carries the consumer's own agent
-# configuration - skills, agents and local settings this script does not own -
-# and sweeping those rewrites them: the fetched update skill ends up naming the
-# consumer's repository instead of the template's, so the next update pulls the
-# wrong project. The '.claude' paths the template itself ships are searched
-# explicitly, because they still carry tokens that must be processed. Shipping
-# another file under '.claude' means listing it here.
+# '.claude' holds both template-owned and consumer-owned files, so it is
+# excluded from the recursive search and its shipped paths are searched
+# explicitly.
 #
 # @param $1 string Needle (string to find)
 # @param $2 string Path relative to the project root to search instead of the


### PR DESCRIPTION
Closes #599

## Summary

`init.sh` rewrites every file under the project root when substituting template tokens, but its exclusion list covered `.git`, `.idea`, `vendor` and `node_modules` and not `.claude`. The `update-consumer-scaffold` skill preserves the consumer's `.claude` directory across its clean-the-root step and then extracts a fresh template on top, so `init.sh` runs over a tree holding both template-owned and consumer-owned files, and the sweep silently rewrote the consumer's own skills, agents and local settings, including the fetched copy of the update skill itself, which afterwards named the consumer's own repository so a later update would pull the wrong project. This was reported against `drevops/behat-steps` on Scaffold 1.2.0. The fix extracts a single `sweep_files()` helper shared by all five sweep functions that excludes `.claude` from the recursive search and then explicitly searches the two template-owned `.claude` paths that still need token substitution.

## Changes

### `init.sh`

- Extracted `sweep_files()`, now shared by `replace_string_content`, `remove_string_content`, `remove_string_content_line`, `remove_tokens_with_content` and `remove_special_comments`. It excludes `.claude` from the recursive tree search, then searches `.claude/settings.json` and `.claude/skills/update-architecture-docs` explicitly so the `AI_ARCH_DOCS_MERMAID` / `AI_ARCH_DOCS_PLANTUML` token blocks in the shipped architecture-docs skill still get processed.
- Removed the grep invocation that was duplicated across all five helpers.
- Dropped the redundant `--include=".*" --include="*"` pair from `remove_tokens_with_content`.
- Removed the `set +e` / `set -e` pair around `replace_string_content`'s pipeline, made unnecessary by its trailing `|| true`.
- Changed `remove_string_content_line`'s default target from `.` to empty, so an argument-less call goes through the protected full sweep instead of an unprotected one.

### `.scaffold/tests/phpunit/src/InitTest.php`

- Added `testInitPreservesConsumerClaudeFiles`, a data-provider-driven test that plants four consumer-owned files under `.claude/` (the fetched update skill, `settings.local.json`, a consumer skill, a consumer agent), each carrying every swept token plus token markers, and asserts each file is byte-identical after `init.sh` runs. This test failed before the fix and passes after.
- Added `testInitProcessesShippedClaudeFiles`, which guards against the exclusion overshooting: the shipped architecture-docs skill must keep the selected diagram format, lose the other, and no file under `.claude/` may retain a `#;` marker or an unsubstituted placeholder.

### `.scaffold/CLAUDE.md`

- Documented the sweep scope and the `.claude` allowlist, and noted that shipping a new file under `.claude` requires adding its path to `sweep_files()`.

## Before / After

```
BEFORE: all five helpers grep the whole tree
┌─────────────────────────────────────────────────────────┐
│ replace_string_content()  remove_string_content()       │
│ remove_string_content_line()                            │
│ remove_tokens_with_content()  remove_special_comments() │
│                                                         │
│ grep -rIl --exclude-dir=.git --exclude-dir=.idea        │
│   --exclude-dir=vendor --exclude-dir=node_modules       │
│   "${needle}" "$(pwd)"                                  │
└─────────────────────────────────────────────────────────┘
                             │
                             ▼
          .claude/ swept like any other directory
                             │
                             ▼
  consumer skills, agents, settings.local.json rewritten
  (including the fetched update-consumer-scaffold skill)

AFTER: one shared helper excludes, then re-admits two paths
┌─────────────────────────────────────────────────────────┐
│ replace_string_content()  remove_string_content()       │
│ remove_string_content_line()                            │
│ remove_tokens_with_content()  remove_special_comments() │
│                                                         │
│ sweep_files(needle, target)                             │
│                                                         │
│ grep -rIl --exclude-dir=.git --exclude-dir=.idea        │
│   --exclude-dir=.claude --exclude-dir=vendor            │
│   --exclude-dir=node_modules "${needle}" "$(pwd)"       │
│ + grep -rIl "${needle}" \                               │
│     "$(pwd)/.claude/settings.json" \                    │
│     "$(pwd)/.claude/skills/update-architecture-docs"    │
└─────────────────────────────────────────────────────────┘
                             │
                             ▼
  .claude/ excluded, except the two template-owned paths
                             │
                             ▼
    consumer-owned .claude files survive byte-identical
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes issue `#599` by preventing `init.sh` from modifying consumer-owned `.claude/` files.

- Adds `sweep_files()` to centralize token-file discovery.
- Excludes consumer-owned `.claude/` content from recursive sweeps.
- Continues processing template-owned `.claude/settings.json` and `update-architecture-docs`.
- Simplifies replacement and error-handling logic.
- Adds tests for consumer-file preservation and shipped-file processing.
- Documents the sweep scope and `.claude` allowlist in `.scaffold/CLAUDE.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->