### PR TITLE
[#596] Stopped renaming the bare word 'scaffold' across the tree.

### DIFF
--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/AGENTS.md
@@ -6,7 +6,7 @@ code in this repository.
 
 ## Project Overview
 
-This project was created from the force-crystal template and provides a foundation
+This project was created from the Scaffold template and provides a foundation
 for Shell scripts, PHP CLI applications, and/or NodeJS projects with integrated
 testing, code quality tools, and CI/CD workflows.
 

--- a/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/shell-command.bats
+++ b/.scaffold/tests/phpunit/fixtures/init/_baseline/tests/bats/shell-command.bats
@@ -3,7 +3,7 @@
 # Test force-crystal.sh functionality.
 #
 # Example usage:
-# ./.force-crystal/tests/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
+# ./tests/bats/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 

--- a/.scaffold/tests/phpunit/fixtures/init/name/AGENTS.md
+++ b/.scaffold/tests/phpunit/fixtures/init/name/AGENTS.md
@@ -1,12 +1,3 @@
-@@ -6,7 +6,7 @@
- 
- ## Project Overview
- 
--This project was created from the force-crystal template and provides a foundation
-+This project was created from the star-forge template and provides a foundation
- for Shell scripts, PHP CLI applications, and/or NodeJS projects with integrated
- testing, code quality tools, and CI/CD workflows.
- 
 @@ -19,7 +19,7 @@
  Multi-command CLI application structure:
  

--- a/.scaffold/tests/phpunit/fixtures/init/name/tests/bats/shell-command.bats
+++ b/.scaffold/tests/phpunit/fixtures/init/name/tests/bats/shell-command.bats
@@ -1,15 +1,11 @@
-@@ -1,9 +1,9 @@
+@@ -1,6 +1,6 @@
  #!/usr/bin/env bats
  #
 -# Test force-crystal.sh functionality.
 +# Test star-forge.sh functionality.
  #
  # Example usage:
--# ./.force-crystal/tests/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
-+# ./.star-forge/tests/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
- #
- # shellcheck disable=SC2030,SC2031,SC2034
- 
+ # ./tests/bats/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
 @@ -12,7 +12,7 @@
  export BATS_HELPERS_FIXTURE_EXPORT_CODEBASE_ENABLED=1
  

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -669,9 +669,9 @@ final class InitTest extends UnitTestCase {
    * extracts the template on top. init.sh then runs over a tree holding both
    * template-owned and consumer-owned files.
    *
-   * A sweep that reaches the consumer's agent configuration renames the
-   * fetched update skill to the consumer's own repository. The next update
-   * then pulls the wrong project.
+   * A sweep that reaches the consumer-owned '.claude' tree rewrites the
+   * fetched update skill to name the consumer's own repository. The next
+   * update then pulls the wrong project.
    *
    * @param string $path
    *   Path of the consumer-owned file, relative to '.claude'.

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -665,11 +665,13 @@ final class InitTest extends UnitTestCase {
   /**
    * Consumer-owned files under '.claude' survive an init run byte-for-byte.
    *
-   * The update flow keeps the consumer's '.claude' across its wipe and then
-   * extracts the template on top, so init.sh runs over a tree holding both
-   * template-owned and consumer-owned files. Sweeping the consumer's agent
-   * configuration rewrote the fetched update skill to name the consumer's own
-   * repository, so a later run would pull the wrong project.
+   * The update flow keeps the consumer's '.claude' across its wipe, then
+   * extracts the template on top. init.sh then runs over a tree holding both
+   * template-owned and consumer-owned files.
+   *
+   * A sweep that reaches the consumer's agent configuration renames the
+   * fetched update skill to the consumer's own repository. The next update
+   * then pulls the wrong project.
    *
    * @param string $path
    *   Path of the consumer-owned file, relative to '.claude'.
@@ -710,7 +712,7 @@ final class InitTest extends UnitTestCase {
    * Every string init.sh sweeps for, in a consumer-owned file.
    *
    * Each line carries a needle from process_internal() or a token marker the
-   * block and comment helpers act on, so any helper that reaches this file
+   * block and comment helpers act on. Any helper that reaches this file
    * changes it.
    */
   protected static function consumerClaudeContent(): string {
@@ -719,6 +721,7 @@ final class InitTest extends UnitTestCase {
       '',
       'gh release list --repo AlexSkrypnyk/scaffold --limit 5',
       'The scaffold template lives at [getscaffold.dev](https://getscaffold.dev).',
+      'This skill scaffolds new data-flow diagrams traced from src/.',
       'Run ./php-command, ./php-script and ./shell-command.sh.',
       'Namespace YourNamespace in yournamespace/yourproject, titled Yourproject.',
       'Authored by Your Name, maintained by Alex Skrypnyk.',
@@ -733,12 +736,11 @@ final class InitTest extends UnitTestCase {
   }
 
   /**
-   * Template-owned '.claude' files are still processed by the sweep helpers.
+   * Template-owned '.claude' files are processed by the sweep helpers.
    *
-   * Excluding '.claude' from the sweep must not overshoot: the shipped
-   * 'update-architecture-docs' skill carries the diagram-format token blocks,
-   * so the unselected format must be gone and no raw '#;' marker or
-   * unsubstituted placeholder may survive anywhere under '.claude'.
+   * The shipped 'update-architecture-docs' skill carries the diagram-format
+   * token blocks. The unselected format is removed, and no raw '#;' marker or
+   * unsubstituted placeholder survives under '.claude'.
    *
    * @param list<string> $arguments
    *   Command-line arguments passed to init.sh.
@@ -762,8 +764,8 @@ final class InitTest extends UnitTestCase {
     $this->assertStringContainsString($present, $content);
     $this->assertStringNotContainsString($absent, $content);
 
-    // The allowlist of swept template paths only holds while no other shipped
-    // '.claude' file needs a substitution. Assert it rather than trust it.
+    // The allowlist holds only while no other shipped '.claude' file needs a
+    // substitution.
     $finder = (new Finder())->files()->in(self::$sut . DIRECTORY_SEPARATOR . '.claude')->ignoreDotFiles(FALSE);
     $placeholders = ['#;', 'YourNamespace', 'yournamespace', 'yourproject', 'Yourproject', 'Your Name'];
 

--- a/.scaffold/tests/phpunit/src/InitTest.php
+++ b/.scaffold/tests/phpunit/src/InitTest.php
@@ -784,6 +784,36 @@ final class InitTest extends UnitTestCase {
     yield 'plantuml when selected' => [['--ai-arch-docs=plantuml'], $plantuml, $mermaid];
   }
 
+  /**
+   * The word 'scaffold' survives outside the template's self-references.
+   *
+   * The rename targets the repository path, the updater skill references and
+   * the attribution footer. A bare-word sweep reaches ordinary prose and
+   * paths that merely contain the word, and rewrites those too.
+   */
+  public function testInitKeepsOrdinaryScaffoldWord(): void {
+    self::$fixtures = NULL;
+
+    $this->processRun(self::$sut . DIRECTORY_SEPARATOR . 'init.sh', [
+      '--namespace=AcmeApp',
+      '--name=acme-app',
+      '--author=Jane Doe',
+    ]);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains('Initialization complete.');
+
+    // A path into the bats binary, which has no relation to the project name.
+    $bats = (string) file_get_contents(self::$sut . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'bats' . DIRECTORY_SEPARATOR . 'shell-command.bats');
+    $this->assertStringContainsString('./tests/bats/node_modules/.bin/bats', $bats);
+    $this->assertStringNotContainsString('acme-app/tests/node_modules', $bats);
+
+    // Prose naming the template the project was generated from.
+    $agents = (string) file_get_contents(self::$sut . DIRECTORY_SEPARATOR . 'AGENTS.md');
+    $this->assertStringContainsString('created from the Scaffold template', $agents);
+    $this->assertStringNotContainsString('created from the acme-app template', $agents);
+  }
+
   protected static function defaultAnswers(): array {
     return [
       'namespace' => 'YodasHut',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ code in this repository.
 
 ## Project Overview
 
-This project was created from the scaffold template and provides a foundation
+This project was created from the Scaffold template and provides a foundation
 for Shell scripts, PHP CLI applications, and/or NodeJS projects with integrated
 testing, code quality tools, and CI/CD workflows.
 

--- a/init.sh
+++ b/init.sh
@@ -713,16 +713,6 @@ process_internal() {
 
   remove_string_content "Generic project scaffold template"
 
-  # Shield the attribution footer from the bulk rename below so its link
-  # text and domain keep naming Scaffold. The needle is a grep/sed regex:
-  # it starts after the "[" (a leading "[Scaffold]" would be a character
-  # class) and escapes the "." so it matches the literal domain. The restore
-  # value is a plain replacement, so it needs neither.
-  replace_string_content "Scaffold](https://getscaffold\.dev/) project template" "__ATTRIBUTION__"
-  replace_string_content "Scaffold" "${project}"
-  replace_string_content "scaffold" "${project}"
-  replace_string_content "__ATTRIBUTION__" "Scaffold](https://getscaffold.dev/) project template"
-
   restore_skill_references
 
   remove_string_content "# Uncomment the lines below"

--- a/tests/bats/shell-command.bats
+++ b/tests/bats/shell-command.bats
@@ -3,7 +3,7 @@
 # Test shell-command.sh functionality.
 #
 # Example usage:
-# ./.scaffold/tests/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
+# ./tests/bats/node_modules/.bin/bats --no-tempdir-cleanup --formatter tap --filter-tags smoke tests/bats
 #
 # shellcheck disable=SC2030,SC2031,SC2034
 


### PR DESCRIPTION
Closes #596

## Summary

`init.sh` replaced the bare words `Scaffold` and `scaffold` with the project name across the whole working tree. This PR removes that tree-wide rename and leaves only the targeted replacements that name the template deliberately: the repository path, the three updater-skill references, and the README attribution footer.

The two corruptions issue 596 reported were both consumer files under `.claude/`, and those were already fixed by PR #600, which excluded `.claude` from the sweeps. Narrowing the needle turned up something the issue did not: **the bare-word rename was also corrupting the template's own shipped files, on every generated project, including a plain fresh `init.sh` run with no consumer content anywhere.**

The bare-word rename was measured rather than assumed. Removing it and re-running `init.sh` shows it changed exactly two lines in a generated project, and both results were wrong:

| File | Bare-word rename produced | Correct |
| --- | --- | --- |
| `tests/bats/shell-command.bats` | `./.force-crystal/tests/node_modules/.bin/bats` | a path that resolves |
| `AGENTS.md` | `This project was created from the force-crystal template` | the template it was actually created from |

Everything else that legitimately needs renaming is already handled by needles that run earlier: `AlexSkrypnyk/scaffold` becomes the project's own repository path, `protect_skill_references()` shields the updater skill's URL, name and trigger phrase, and the attribution footer names Scaffold on purpose.

## Changes

### `init.sh`

- Removed `replace_string_content "Scaffold"` and `replace_string_content "scaffold"`. Nothing replaces them: every rename that was wanted is covered by the more specific needles that run before them.
- Removed the `__ATTRIBUTION__` shield and its explanatory comment. It existed only to hide the README footer from those two calls, so with them gone it was a no-op round trip. `testInitPreservesAttributionFooter` still passes without it, which is the proof it is no longer load-bearing.

`protect_skill_references()` is kept as it is. Two of its three shields no longer match any remaining needle, but proving that no future needle can match them is harder than keeping three cheap replacements, and the existing tests depend on the guarantee.

### Template files the rename was corrupting

- `tests/bats/shell-command.bats`: the example-usage path is now `./tests/bats/node_modules/.bin/bats`, which resolves both in this repository and in a generated project, and contains no word that any needle targets.
- `AGENTS.md`: `created from the scaffold template` is now `created from the Scaffold template`, so a generated project correctly names the template it came from instead of naming itself.

### `.scaffold/tests/phpunit/src/InitTest.php`

- Added `testInitKeepsOrdinaryScaffoldWord`, which asserts the bats example path resolves and that `AGENTS.md` names Scaffold rather than the project. Written first and watched fail before the fix.
- Added issue 596's reproduction string, `This skill scaffolds new data-flow diagrams traced from src/.`, to the consumer-file content planted by `testInitPreservesConsumerClaudeFiles`. This is the case 596 distinguishes: `scaffold` used as an ordinary English verb with a suffix rather than as the template's name.
- Converged the docblocks added in PR #600 onto the technical register: present tense instead of narrating the fixed bug in past tense, and sentences within the length limit.

### Fixtures

Regenerated. Beyond the two corrected lines in `_baseline`, the `name` scenario lost patches: those lines no longer vary with the project name, so there is less project-name coupling in generated output than before.

## Before / After

```
BEFORE: the bare word is swept everywhere
┌──────────────────────────────────────────────────────────┐
│ replace_string_content "AlexSkrypnyk/scaffold"  -> repo   │
│ protect_skill_references()                      -> shield │
│ replace_string_content "Scaffold..." -> __ATTRIBUTION__   │
│ replace_string_content "Scaffold"    -> ${project}   <──┐ │
│ replace_string_content "scaffold"    -> ${project}   <──┤ │
│ replace_string_content "__ATTRIBUTION__" -> footer      │ │
└─────────────────────────────────────────────────────────┼┘
                                                          │
   every occurrence of the word, in any file, renamed ────┘
                          │
                          ▼
   tests/bats/shell-command.bats
     ./.scaffold/tests/...  ->  ./.force-crystal/tests/...   broken path
   AGENTS.md
     from the scaffold template -> from the force-crystal template   wrong

AFTER: only deliberate self-references are renamed
┌──────────────────────────────────────────────────────────┐
│ replace_string_content "AlexSkrypnyk/scaffold"  -> repo   │
│ protect_skill_references()                      -> shield │
└──────────────────────────────────────────────────────────┘
                          │
        the bare word is never swept; ordinary prose
        and paths keep the word they were written with
                          │
                          ▼
   tests/bats/shell-command.bats
     ./tests/bats/node_modules/.bin/bats            resolves
   AGENTS.md
     created from the Scaffold template             correct
```
